### PR TITLE
Updated paths & settings for MacOS build.

### DIFF
--- a/OpenEmulator.xcodeproj/project.pbxproj
+++ b/OpenEmulator.xcodeproj/project.pbxproj
@@ -7,305 +7,328 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00039CF812B01D540025D374 /* EmulationUnmountPressed.png in Resources */ = {isa = PBXBuildFile; fileRef = 00039CEB12B01D530025D374 /* EmulationUnmountPressed.png */; };
-		00039CFF12B01D540025D374 /* EmulationShowPressed.png in Resources */ = {isa = PBXBuildFile; fileRef = 00039CF212B01D530025D374 /* EmulationShowPressed.png */; };
-		00039D2612B01EB40025D374 /* EmulationUnmountSelected.png in Resources */ = {isa = PBXBuildFile; fileRef = 00039D2412B01EB40025D374 /* EmulationUnmountSelected.png */; };
-		00039D2712B01EB40025D374 /* EmulationShowSelected.png in Resources */ = {isa = PBXBuildFile; fileRef = 00039D2512B01EB40025D374 /* EmulationShowSelected.png */; };
-		00039E0C12B0365A0025D374 /* EmulationUnmountRollover.png in Resources */ = {isa = PBXBuildFile; fileRef = 00039E0A12B0365A0025D374 /* EmulationUnmountRollover.png */; };
-		00039E0D12B0365A0025D374 /* EmulationShowRollover.png in Resources */ = {isa = PBXBuildFile; fileRef = 00039E0B12B0365A0025D374 /* EmulationShowRollover.png */; };
 		00039E9B12B042210025D374 /* libemulation-hal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00039E7C12B03F660025D374 /* libemulation-hal.a */; };
 		00039F0112B04EAA0025D374 /* libemulation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00039EFE12B04E910025D374 /* libemulation.a */; };
 		00039FD112B04F6C0025D374 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 00039FD012B04F6C0025D374 /* libxml2.dylib */; };
-		0009068E141D2A0300F06D99 /* NSStringAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0009068D141D2A0300F06D99 /* NSStringAdditions.mm */; };
-		00092E5C156AA9D4007A9E04 /* VRAM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00092E5A156AA9D4007A9E04 /* VRAM.cpp */; };
-		00092E5D156AA9D4007A9E04 /* VRAM.h in Headers */ = {isa = PBXBuildFile; fileRef = 00092E5B156AA9D4007A9E04 /* VRAM.h */; };
-		00139F84151195E600B0E108 /* AppleIIAddressDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00139F83151195E600B0E108 /* AppleIIAddressDecoder.cpp */; };
-		00140DF0152D282400D4795D /* DIApple525DiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00140DEF152D282400D4795D /* DIApple525DiskStorage.cpp */; };
-		00140DF6152D36F900D4795D /* DIFileBackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00140DF5152D36F900D4795D /* DIFileBackingStore.cpp */; };
-		00140DFC152D371C00D4795D /* DI2IMGBackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00140DFB152D371C00D4795D /* DI2IMGBackingStore.cpp */; };
-		00140E04152D376400D4795D /* DIFDIDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00140E03152D376400D4795D /* DIFDIDiskStorage.cpp */; };
-		00140E0C152D37F500D4795D /* DIDC42BackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00140E0B152D37F400D4795D /* DIDC42BackingStore.cpp */; };
-		00140E12152D395900D4795D /* DIV2DDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00140E11152D395900D4795D /* DIV2DDiskStorage.cpp */; };
-		0014DF14148286A5006A7660 /* Application.m in Sources */ = {isa = PBXBuildFile; fileRef = 0014DF13148286A5006A7660 /* Application.m */; };
-		0019177E1543D321009A301E /* DIDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0019177D1543D320009A301E /* DIDiskStorage.cpp */; };
-		001917821543D347009A301E /* DILogicalDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 001917811543D346009A301E /* DILogicalDiskStorage.cpp */; };
-		001C9B02137FDD0500D1355B /* AudioRecord.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED379A12779AD000BEF6BD /* AudioRecord.png */; };
-		001E096C1556339800405DC0 /* AppleLanguageCard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 001E09691556339400405DC0 /* AppleLanguageCard.cpp */; };
-		001E0970155633D000405DC0 /* AppleIIAudioIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8881912A393990052B7A4 /* AppleIIAudioIn.cpp */; };
-		001E0971155633E700405DC0 /* Apple1Terminal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00722D3B1470E31400FE7007 /* Apple1Terminal.cpp */; };
-		001F56F90FD1E8E500EA246A /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 001F56F80FD1E8E500EA246A /* Sparkle.framework */; };
-		0020AE731530A22700E3DF80 /* DICommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0020AE721530A22700E3DF80 /* DICommon.cpp */; };
-		00247F38139D8F4C00B165D1 /* OECommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00247F35139D85A900B165D1 /* OECommon.cpp */; };
-		002740B813A08A4F00E13D65 /* VidexVideoterm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 002740B613A08A4F00E13D65 /* VidexVideoterm.cpp */; };
-		0027E67E153738CC0066A9BE /* DIVDIBlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0027E67D153738CC0066A9BE /* DIVDIBlockStorage.cpp */; };
-		0029EEE214266B8900AD900E /* AddressMapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0029EEDF14266B7700AD900E /* AddressMapper.cpp */; };
 		002F57E615CDF4AC00C19659 /* libz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57E515CDF4AC00C19659 /* libz.a */; };
 		002F57E815CDF4B400C19659 /* libvorbis.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57E715CDF4B400C19659 /* libvorbis.a */; };
 		002F57EA15CDF4B900C19659 /* libzip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57E915CDF4B900C19659 /* libzip.a */; };
 		002F57EC15CDF4C000C19659 /* libsndfile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57EB15CDF4C000C19659 /* libsndfile.a */; };
 		002F57EE15CDF4C600C19659 /* libsamplerate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57ED15CDF4C600C19659 /* libsamplerate.a */; };
 		002F57F015CDF4CB00C19659 /* libportaudio.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57EF15CDF4CB00C19659 /* libportaudio.a */; };
-		002F57F215CDF4D100C19659 /* libpng14.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57F115CDF4D100C19659 /* libpng14.a */; };
 		002F57F415CDF66B00C19659 /* libogg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57F315CDF66B00C19659 /* libogg.a */; };
-		002F57F615CDF6DF00C19659 /* libFLAC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57F515CDF6DF00C19659 /* libFLAC.a */; };
 		002F57F815CDF6F800C19659 /* libvorbisenc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 002F57F715CDF6F800C19659 /* libvorbisenc.a */; };
-		00365CEB1516955C00978DF6 /* AddressMux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00365CEA1516955C00978DF6 /* AddressMux.cpp */; };
 		00365CFA1516F4E700978DF6 /* libdiskimage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00365CF51516F3D800978DF6 /* libdiskimage.a */; };
-		00379132157B285F0020138F /* AppleGraphicsTabletInterfaceCard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00379130157B285E0020138F /* AppleGraphicsTabletInterfaceCard.cpp */; };
-		00379133157B285F0020138F /* AppleGraphicsTabletInterfaceCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 00379131157B285E0020138F /* AppleGraphicsTabletInterfaceCard.h */; };
-		00391CB312D3A320002C5ABD /* LibraryWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 00391CB212D3A320002C5ABD /* LibraryWindowController.m */; };
-		00391D6112D3B570002C5ABD /* IconLibrary.png in Resources */ = {isa = PBXBuildFile; fileRef = 00391D6012D3B570002C5ABD /* IconLibrary.png */; };
-		00391D6412D3B588002C5ABD /* Library.xib in Resources */ = {isa = PBXBuildFile; fileRef = 00391D6212D3B588002C5ABD /* Library.xib */; };
-		00391DAC12D3B94F002C5ABD /* library in Resources */ = {isa = PBXBuildFile; fileRef = 00391D9912D3B94F002C5ABD /* library */; };
-		00391F6C12D3FFF3002C5ABD /* TemplateChooserView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 00391F6A12D3FFF3002C5ABD /* TemplateChooserView.xib */; };
-		0039211812D43448002C5ABD /* BackgroundView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0040284112B44878001C2F73 /* BackgroundView.m */; };
 		003B167C12EE27ED003FB8F6 /* CoreAudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 003B167B12EE27ED003FB8F6 /* CoreAudioKit.framework */; };
 		003B16B212EE2A05003FB8F6 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 003B165712EE276E003FB8F6 /* AudioToolbox.framework */; };
 		003B16B712EE2A0D003FB8F6 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 003B165112EE275C003FB8F6 /* AudioUnit.framework */; };
 		003B16C312EE2A18003FB8F6 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 003B158312EE26BA003FB8F6 /* CoreAudio.framework */; };
 		003B16C812EE2A61003FB8F6 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 003B16C712EE2A61003FB8F6 /* CoreServices.framework */; };
-		003E25E71070796700185260 /* images in Resources */ = {isa = PBXBuildFile; fileRef = 003E2597107075D900185260 /* images */; };
-		0042499015B693DE0091ECAB /* AppleIIIMOS6502.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0042498E15B693DE0091ECAB /* AppleIIIMOS6502.cpp */; };
-		0042499115B693DE0091ECAB /* AppleIIIMOS6502.h in Headers */ = {isa = PBXBuildFile; fileRef = 0042498F15B693DE0091ECAB /* AppleIIIMOS6502.h */; };
-		0042499315B694A60091ECAB /* AppleIIIMOS6502Opcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 0042499215B694A60091ECAB /* AppleIIIMOS6502Opcodes.h */; };
-		0042499515B696EA0091ECAB /* AppleIIIMOS6502Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 0042499415B696EA0091ECAB /* AppleIIIMOS6502Operations.h */; };
-		0042499715B8EA1C0091ECAB /* EmulationInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 0042499615B8EA1C0091ECAB /* EmulationInterface.h */; };
-		0044FDD515D3784500F82C28 /* MM58167.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0044FDD315D3784500F82C28 /* MM58167.cpp */; };
-		004763D2139C94F30016277E /* LibraryTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 004763D1139C94F30016277E /* LibraryTableView.m */; };
-		004BD1C01425AA8500768B80 /* W65C02S.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 004BD1BC1425AA8500768B80 /* W65C02S.cpp */; };
-		004E152A15B9041A00FD22AB /* AppleIIISystemControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 004E152915B9041A00FD22AB /* AppleIIISystemControl.cpp */; };
-		004E152D15B9042100FD22AB /* AppleIIISystemControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 004E152C15B9042100FD22AB /* AppleIIISystemControl.h */; };
-		005316C31596D268007F3C86 /* AppleSilentypeInterfaceCard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 005316C21596D268007F3C86 /* AppleSilentypeInterfaceCard.cpp */; };
-		005316C51596D2BF007F3C86 /* Proxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 005316C41596D2BF007F3C86 /* Proxy.h */; };
-		005316C71596D2C8007F3C86 /* Proxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 005316C61596D2C8007F3C86 /* Proxy.cpp */; };
-		00536BC6153DD400005A5336 /* DIVMDKBlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00536BC5153DD400005A5336 /* DIVMDKBlockStorage.cpp */; };
-		005486CA0FDC84E500DBCFA8 /* Sparkle.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 001F56F80FD1E8E500EA246A /* Sparkle.framework */; };
 		0054E4A11131BE7A006D32D9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0054E4A01131BE7A006D32D9 /* Cocoa.framework */; };
 		0054E4A71131BE8A006D32D9 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0054E4A61131BE8A006D32D9 /* OpenGL.framework */; };
 		0054E6311131BEE7006D32D9 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0054E6301131BEE7006D32D9 /* Carbon.framework */; };
 		0054E66C1131BF58006D32D9 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0054E66B1131BF58006D32D9 /* Quartz.framework */; };
-		00651A55155AE23500221A44 /* HIDJoystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A12994147A8E7500DF323F /* HIDJoystick.cpp */; };
-		00651A56155AE23C00221A44 /* OEMatrix3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00D226551350FF8B00FC69B9 /* OEMatrix3.cpp */; };
-		00651A57155AE3DF00221A44 /* MemoryInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A90FB2150D3A0000BB2999 /* MemoryInterface.cpp */; };
-		00679D09100817F700B38748 /* TemplateChooser.xib in Resources */ = {isa = PBXBuildFile; fileRef = 00679D06100817F700B38748 /* TemplateChooser.xib */; };
-		006B5CD013826D0700EEB5BC /* CanvasWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 00A72B7212879F800083C6A7 /* CanvasWindow.m */; };
-		0071E3BA10803F7300F2D54F /* TemplateChooserItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0071E3B910803F7300F2D54F /* TemplateChooserItem.mm */; };
-		0073DD9F136FCC1100087303 /* CanvasToolbarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0073DD8E136FCA1C00087303 /* CanvasToolbarView.m */; };
-		0073DDBF136FCCC900087303 /* ToolbarBackground.png in Resources */ = {isa = PBXBuildFile; fileRef = 0073DDBE136FCCC900087303 /* ToolbarBackground.png */; };
-		0076FD6512A1ED8C00A3FEC7 /* AudioPause.png in Resources */ = {isa = PBXBuildFile; fileRef = 0076FD6412A1ED8C00A3FEC7 /* AudioPause.png */; };
-		0077272015D81387008AB5A2 /* AppleIIIBeeper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0077271F15D81387008AB5A2 /* AppleIIIBeeper.cpp */; };
-		0078F655127348ED0042577E /* AudioControls.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0078F653127348ED0042577E /* AudioControls.xib */; };
-		007A0B0C15EDD16100DFD300 /* AppleIIIVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 008CB9A915E7B0AE00027B7B /* AppleIIIVideo.cpp */; };
-		007DEFAF153FB16800A9CC01 /* DIRAMBackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 007DEFAE153FB16800A9CC01 /* DIRAMBackingStore.cpp */; };
-		007DEFB1153FB17500A9CC01 /* DIBackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 007DEFB0153FB17500A9CC01 /* DIBackingStore.cpp */; };
-		007DEFB3153FB5E800A9CC01 /* DIBlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 007DEFB2153FB5E800A9CC01 /* DIBlockStorage.cpp */; };
-		007DEFBB1540608300A9CC01 /* DIRAWBlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 007DEFBA1540608200A9CC01 /* DIRAWBlockStorage.cpp */; };
-		007EF9C71570329D0073061E /* IconRevert.png in Resources */ = {isa = PBXBuildFile; fileRef = 007EF9C61570329D0073061E /* IconRevert.png */; };
-		007F08CF1459344600C3308D /* sparkle_dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 007F08CE1459344600C3308D /* sparkle_dsa_pub.pem */; };
-		007F6C3715CD05370004D4C4 /* AppleIIIAddressDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 007F6C3615CD05370004D4C4 /* AppleIIIAddressDecoder.cpp */; };
-		007F6C3A15CD06520004D4C4 /* MOS6551.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 007F6C3915CD06520004D4C4 /* MOS6551.cpp */; };
-		007F6C3D15CD06930004D4C4 /* AppleIIIGamePort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 007F6C3C15CD06930004D4C4 /* AppleIIIGamePort.cpp */; };
-		008107DE1120C57600D744FB /* TemplateChooserViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 00FE0C051095353B00B92AB7 /* TemplateChooserViewController.m */; };
-		00811E0012D251E9009AD2F0 /* AppleDiskIIInterfaceCard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00811DFE12D251E9009AD2F0 /* AppleDiskIIInterfaceCard.cpp */; };
-		00811F1312D2738B009AD2F0 /* AppleGraphicsTablet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00811F1112D2738B009AD2F0 /* AppleGraphicsTablet.cpp */; };
-		0083630D1326C15300CB9A21 /* OpenGLCanvas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 008363051326C15300CB9A21 /* OpenGLCanvas.cpp */; };
-		0083630F1326C15300CB9A21 /* OEVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 008363071326C15300CB9A21 /* OEVector.cpp */; };
-		008363111326C15300CB9A21 /* PAAudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 008363091326C15300CB9A21 /* PAAudio.cpp */; };
-		00839E481597060200BD4538 /* ATAController.h in Headers */ = {isa = PBXBuildFile; fileRef = 00839E45159705FC00BD4538 /* ATAController.h */; };
-		00839E491597060700BD4538 /* ATAController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00839E44159705FC00BD4538 /* ATAController.cpp */; };
-		0084D43614FC4FF80031A8A5 /* Audio1Bit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0084D43514FC4FF80031A8A5 /* Audio1Bit.cpp */; };
-		008696AD15C8FC94000737EE /* AppleIIIDiskIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 008696AC15C8FC93000737EE /* AppleIIIDiskIO.cpp */; };
-		008696B015CB9048000737EE /* AppleIISystemControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 008696AF15CB9047000737EE /* AppleIISystemControl.cpp */; };
 		008CA97E147803E500B9F5D0 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 008CA97D147803E500B9F5D0 /* IOKit.framework */; };
-		008CB9A715E7B08A00027B7B /* AppleIIIRTC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 008CB9A615E7B08A00027B7B /* AppleIIIRTC.cpp */; };
-		008F2FE7138E0AD600409723 /* DocumentController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 00AD746811A2F10E00BAC29C /* DocumentController.mm */; };
-		009085401395D23D00B7D75F /* LibraryItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0090853F1395D23D00B7D75F /* LibraryItem.mm */; };
-		00936E8815170435006B0EAC /* AudioPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00936E8715170435006B0EAC /* AudioPlayer.cpp */; };
-		00954E781277B79E00C17203 /* EmulationOutlineCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 00954E771277B79E00C17203 /* EmulationOutlineCell.m */; };
-		00954E991277BB8E00C17203 /* EmulationWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 00954E981277BB8E00C17203 /* EmulationWindowController.m */; };
-		00954EA71277BC1200C17203 /* AudioControlsWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 00954EA61277BC1200C17203 /* AudioControlsWindowController.mm */; };
-		00A06AE31533055600A494A7 /* DIATABlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A06AE21533055600A494A7 /* DIATABlockStorage.cpp */; };
-		00A06AE91533EE3100A494A7 /* DIApple35DiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A06AE81533EE3100A494A7 /* DIApple35DiskStorage.cpp */; };
-		00A0B8041069761A007930A5 /* Document.mm in Sources */ = {isa = PBXBuildFile; fileRef = 00A0B8031069761A007930A5 /* Document.mm */; };
-		00A72B6F12879F650083C6A7 /* CanvasView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 00A72B6E12879F650083C6A7 /* CanvasView.mm */; };
-		00A72B7012879F690083C6A7 /* CanvasWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 00A72B6A12879F530083C6A7 /* CanvasWindowController.m */; };
-		00A72B951287A0F10083C6A7 /* Canvas.xib in Resources */ = {isa = PBXBuildFile; fileRef = 00A72B931287A0F10083C6A7 /* Canvas.xib */; };
-		00A90FB5150D3A0E00BB2999 /* AudioInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A90FB4150D3A0E00BB2999 /* AudioInterface.cpp */; };
-		00A973AB12E512F80084724F /* OEEmulation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A9739E12E512F80084724F /* OEEmulation.cpp */; };
-		00A973AD12E512F80084724F /* OEComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A973A012E512F80084724F /* OEComponent.cpp */; };
-		00A973AF12E512F80084724F /* OEComponentFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A973A212E512F80084724F /* OEComponentFactory.cpp */; };
-		00A973B112E512F80084724F /* OEDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A973A412E512F80084724F /* OEDocument.cpp */; };
-		00A973B312E512F80084724F /* OEImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A973A612E512F80084724F /* OEImage.cpp */; };
-		00A973B512E512F80084724F /* OEPackage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00A973A812E512F80084724F /* OEPackage.cpp */; };
-		00AB963F157F9EBE00EDACD5 /* Apple1ACI.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8881412A393990052B7A4 /* Apple1ACI.h */; };
-		00AB9640157F9EBE00EDACD5 /* Apple1IO.h in Headers */ = {isa = PBXBuildFile; fileRef = 00F397E5141655EB00C53A3E /* Apple1IO.h */; };
-		00AB9641157F9EBE00EDACD5 /* Apple1Terminal.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8881812A393990052B7A4 /* Apple1Terminal.h */; };
-		00AB9642157F9EBE00EDACD5 /* AppleDiskDrive525.h in Headers */ = {isa = PBXBuildFile; fileRef = 00044CA112CE6FD400D26940 /* AppleDiskDrive525.h */; };
-		00AB9643157F9EBE00EDACD5 /* AppleDiskIIInterfaceCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 00811DFD12D251E9009AD2F0 /* AppleDiskIIInterfaceCard.h */; };
-		00AB9644157F9EBE00EDACD5 /* AppleGraphicsTablet.h in Headers */ = {isa = PBXBuildFile; fileRef = 00811F1012D2738B009AD2F0 /* AppleGraphicsTablet.h */; };
-		00AB9645157F9EBE00EDACD5 /* AppleLanguageCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 001E096A1556339400405DC0 /* AppleLanguageCard.h */; };
-		00AB9646157F9EBE00EDACD5 /* AppleIIAddressDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 00139F85151195EE00B0E108 /* AppleIIAddressDecoder.h */; };
-		00AB9647157F9EBE00EDACD5 /* AppleIIAudioIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8881A12A393990052B7A4 /* AppleIIAudioIn.h */; };
-		00AB9648157F9EBE00EDACD5 /* AppleIIAudioOut.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8881C12A393990052B7A4 /* AppleIIAudioOut.h */; };
-		00AB9649157F9EBE00EDACD5 /* AppleIIFloatingBus.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8882012A393990052B7A4 /* AppleIIFloatingBus.h */; };
-		00AB964A157F9EBE00EDACD5 /* AppleIIGamePort.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B7C647147B5B2300BB7E6B /* AppleIIGamePort.h */; };
-		00AB964B157F9EBE00EDACD5 /* AppleIIKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8882412A393990052B7A4 /* AppleIIKeyboard.h */; };
-		00AB964C157F9EBE00EDACD5 /* AppleIISlotController.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8882A12A393990052B7A4 /* AppleIISlotController.h */; };
-		00AB964D157F9EBE00EDACD5 /* AppleIIVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8882C12A393990052B7A4 /* AppleIIVideo.h */; };
-		00AB964E157F9EBE00EDACD5 /* AppleSilentype.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B5CB93136F0B6C007A7BED /* AppleSilentype.h */; };
-		00AB964F157F9EBE00EDACD5 /* AppleSilentypeInterfaceCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AB963B157F9E8200EDACD5 /* AppleSilentypeInterfaceCard.h */; };
-		00AB9650157F9EC700EDACD5 /* AddressDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8882F12A393990052B7A4 /* AddressDecoder.h */; };
-		00AB9651157F9EC700EDACD5 /* AddressMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0029EEE114266B8000AD900E /* AddressMapper.h */; };
-		00AB9652157F9EC700EDACD5 /* AddressMux.h in Headers */ = {isa = PBXBuildFile; fileRef = 00365CEC1516956600978DF6 /* AddressMux.h */; };
-		00AB9653157F9EC700EDACD5 /* AddressOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8883112A393990052B7A4 /* AddressOffset.h */; };
-		00AB9654157F9EC700EDACD5 /* Audio1Bit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0084D43714FC50060031A8A5 /* Audio1Bit.h */; };
-		00AB9655157F9EC700EDACD5 /* AudioCodec.h in Headers */ = {isa = PBXBuildFile; fileRef = 00FBD2DD1419A03A00BA8CEE /* AudioCodec.h */; };
-		00AB9656157F9EC700EDACD5 /* AudioPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 00936E8515170428006B0EAC /* AudioPlayer.h */; };
-		00AB9658157F9EC700EDACD5 /* ControlBus.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8883912A393990052B7A4 /* ControlBus.h */; };
-		00AB9659157F9EC700EDACD5 /* FloatingBus.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8883B12A393990052B7A4 /* FloatingBus.h */; };
-		00AB965A157F9EC700EDACD5 /* JoystickMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B7C644147B4B2B00BB7E6B /* JoystickMapper.h */; };
-		00AB965B157F9EC700EDACD5 /* Monitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8883712A393990052B7A4 /* Monitor.h */; };
-		00AB965C157F9EC700EDACD5 /* RAM.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8883D12A393990052B7A4 /* RAM.h */; };
-		00AB965D157F9EC700EDACD5 /* ROM.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8883F12A393990052B7A4 /* ROM.h */; };
-		00AB965E157F9ECF00EDACD5 /* MOS6502.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8884412A393990052B7A4 /* MOS6502.h */; };
-		00AB965F157F9ECF00EDACD5 /* MOS6502IllegalOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8884512A393990052B7A4 /* MOS6502IllegalOperations.h */; };
-		00AB9660157F9ECF00EDACD5 /* MOS6502Opcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8884612A393990052B7A4 /* MOS6502Opcodes.h */; };
-		00AB9661157F9ECF00EDACD5 /* MOS6502Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8884712A393990052B7A4 /* MOS6502Operations.h */; };
-		00AB9662157F9ECF00EDACD5 /* MOS6530.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8884D12A393990052B7A4 /* MOS6530.h */; };
-		00AB9663157F9ECF00EDACD5 /* MOSKIM1IO.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8884F12A393990052B7A4 /* MOSKIM1IO.h */; };
-		00AB9664157F9ECF00EDACD5 /* MOSKIM1PLL.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8885112A393990052B7A4 /* MOSKIM1PLL.h */; };
-		00AB9665157F9ED600EDACD5 /* MC6821.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8885412A393990052B7A4 /* MC6821.h */; };
-		00AB9666157F9ED600EDACD5 /* MC6845.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8885612A393990052B7A4 /* MC6845.h */; };
-		00AB966A157F9EE400EDACD5 /* W65C02S.h in Headers */ = {isa = PBXBuildFile; fileRef = 004BD1BD1425AA8500768B80 /* W65C02S.h */; };
-		00AB966B157F9EE400EDACD5 /* W65C02SOpcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 004BD1BE1425AA8500768B80 /* W65C02SOpcodes.h */; };
-		00AB966C157F9EE400EDACD5 /* W65C02SOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 004BD1BF1425AA8500768B80 /* W65C02SOperations.h */; };
-		00AB966D157F9EF000EDACD5 /* AppleIIInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8886B12A393990052B7A4 /* AppleIIInterface.h */; };
-		00AB966E157F9EF400EDACD5 /* RS232Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8886D12A393990052B7A4 /* RS232Interface.h */; };
-		00AB966F157F9EFE00EDACD5 /* AudioPlayerInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00936E8915177B60006B0EAC /* AudioPlayerInterface.h */; };
-		00AB9670157F9EFE00EDACD5 /* ControlBusInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 0022236B142C557100B7451D /* ControlBusInterface.h */; };
-		00AB9671157F9EFE00EDACD5 /* CPUInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 001CC97E13D11EBC00B0DDA7 /* CPUInterface.h */; };
-		00AB9672157F9EFE00EDACD5 /* MemoryInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00DC0E78145DFECD00FF51BD /* MemoryInterface.h */; };
-		00AB9673157F9F0200EDACD5 /* DeviceInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D225FD1350F9A100FC69B9 /* DeviceInterface.h */; };
-		00AB9674157F9F0200EDACD5 /* AudioInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D225FA1350F9A100FC69B9 /* AudioInterface.h */; };
-		00AB9675157F9F0200EDACD5 /* CanvasInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D225FB1350F9A100FC69B9 /* CanvasInterface.h */; };
-		00AB9676157F9F0200EDACD5 /* StorageInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 000E8D1813515C6E00DBFB2C /* StorageInterface.h */; };
-		00AB9677157F9F0200EDACD5 /* JoystickInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 001D1F7A1479E7BD0014D496 /* JoystickInterface.h */; };
-		00AB9678157F9F0200EDACD5 /* EthernetInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D225FF1350F9A100FC69B9 /* EthernetInterface.h */; };
-		00AB9679157F9F0200EDACD5 /* MIDIInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D226001350F9A100FC69B9 /* MIDIInterface.h */; };
-		00AB967A157F9F0200EDACD5 /* USBInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D226031350F9A100FC69B9 /* USBInterface.h */; };
-		00AB967B157F9F0200EDACD5 /* VideoCaptureInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D226041350F9A100FC69B9 /* VideoCaptureInterface.h */; };
-		00AB967C157F9F0700EDACD5 /* IEEE488Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 006A4C5B134ED2F30033BE4D /* IEEE488Interface.h */; };
-		00AB967D157F9F0700EDACD5 /* IEEE1284Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8887F12A393990052B7A4 /* IEEE1284Interface.h */; };
-		00AB967E157F9F0700EDACD5 /* IEEE1394Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D73D9C136CC9B300BD5465 /* IEEE1394Interface.h */; };
-		00AB967F157F9F1800EDACD5 /* diskimage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00E473411475695500F367B7 /* diskimage.h */; };
-		00AB9680157F9F1800EDACD5 /* DICommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 0020AE701530A21F00E3DF80 /* DICommon.h */; };
-		00AB9681157F9F1800EDACD5 /* DIBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 007DEFAA153FB0CB00A9CC01 /* DIBackingStore.h */; };
-		00AB9682157F9F1800EDACD5 /* DIFileBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 00140DF7152D370300D4795D /* DIFileBackingStore.h */; };
-		00AB9683157F9F1800EDACD5 /* DIRAMBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 007DEFAC153FB15C00A9CC01 /* DIRAMBackingStore.h */; };
-		00AB9684157F9F1800EDACD5 /* DI2IMGBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 00140DF9152D371000D4795D /* DI2IMGBackingStore.h */; };
-		00AB9685157F9F1800EDACD5 /* DIDC42BackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 00140E09152D37ED00D4795D /* DIDC42BackingStore.h */; };
-		00AB9686157F9F1800EDACD5 /* DIBlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 007DEFB4153FB5EF00A9CC01 /* DIBlockStorage.h */; };
-		00AB9687157F9F1800EDACD5 /* DIRAWBlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 007DEFB81540607C00A9CC01 /* DIRAWBlockStorage.h */; };
-		00AB9688157F9F1800EDACD5 /* DIVDIBlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0027E67F153738D30066A9BE /* DIVDIBlockStorage.h */; };
-		00AB9689157F9F1800EDACD5 /* DIVMDKBlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00536BC4153DD3F5005A5336 /* DIVMDKBlockStorage.h */; };
-		00AB968A157F9F1800EDACD5 /* DIDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0019177B1543D319009A301E /* DIDiskStorage.h */; };
-		00AB968B157F9F1800EDACD5 /* DILogicalDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0019177F1543D337009A301E /* DILogicalDiskStorage.h */; };
-		00AB968C157F9F1800EDACD5 /* DIFDIDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00140E01152D375D00D4795D /* DIFDIDiskStorage.h */; };
-		00AB968D157F9F1800EDACD5 /* DIV2DDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00140E13152D396500D4795D /* DIV2DDiskStorage.h */; };
-		00AB968E157F9F1800EDACD5 /* DIATABlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A06AE41533055D00A494A7 /* DIATABlockStorage.h */; };
-		00AB968F157F9F1800EDACD5 /* DIApple525DiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00140DED152D281F00D4795D /* DIApple525DiskStorage.h */; };
-		00AB9690157F9F1800EDACD5 /* DIApple35DiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A06AE61533EE2700A494A7 /* DIApple35DiskStorage.h */; };
-		00AB9691157F9F2600EDACD5 /* OECommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 00247F36139D85AA00B165D1 /* OECommon.h */; };
-		00AB9692157F9F2600EDACD5 /* OEComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A973A112E512F80084724F /* OEComponent.h */; };
-		00AB9693157F9F2600EDACD5 /* OEComponentFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A973A312E512F80084724F /* OEComponentFactory.h */; };
-		00AB9694157F9F2600EDACD5 /* OEDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B019B213501507001E01BB /* OEDevice.h */; };
-		00AB9695157F9F2600EDACD5 /* OEDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A973A512E512F80084724F /* OEDocument.h */; };
-		00AB9696157F9F2600EDACD5 /* OEEmulation.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A9739F12E512F80084724F /* OEEmulation.h */; };
-		00AB9697157F9F2600EDACD5 /* OEImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A973A712E512F80084724F /* OEImage.h */; };
-		00AB9698157F9F2600EDACD5 /* OEPackage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A973A912E512F80084724F /* OEPackage.h */; };
-		00AB9699157F9F2600EDACD5 /* OESound.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD7025151AC19100424637 /* OESound.h */; };
-		00AB96A0157FA02F00EDACD5 /* OpenGLCanvas.h in Headers */ = {isa = PBXBuildFile; fileRef = 008363061326C15300CB9A21 /* OpenGLCanvas.h */; };
-		00AB96A1157FA02F00EDACD5 /* PAAudio.h in Headers */ = {isa = PBXBuildFile; fileRef = 0083630A1326C15300CB9A21 /* PAAudio.h */; };
-		00AB96A2157FA02F00EDACD5 /* OEVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 008363081326C15300CB9A21 /* OEVector.h */; };
-		00AB96A3157FA02F00EDACD5 /* OEMatrix3.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D226541350FF8B00FC69B9 /* OEMatrix3.h */; };
-		00AB96A4157FA02F00EDACD5 /* HIDJoystick.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A12996147A8E7E00DF323F /* HIDJoystick.h */; };
-		00AB96A7158053C400EDACD5 /* AppleIIDisableC800.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00AB96A5158053BF00EDACD5 /* AppleIIDisableC800.cpp */; };
-		00AB96A8158053C400EDACD5 /* AppleIIDisableC800.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AB96A6158053C000EDACD5 /* AppleIIDisableC800.h */; };
-		00AD7028151AC41E00424637 /* OESound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00AD7027151AC41E00424637 /* OESound.cpp */; };
-		00B019B513501507001E01BB /* OEDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B019B313501507001E01BB /* OEDevice.cpp */; };
-		00B5709E10863C2A00CDE4A7 /* TemplateChooserWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 00B5709D10863C2A00CDE4A7 /* TemplateChooserWindowController.m */; };
-		00B5CB94136F0B6C007A7BED /* AppleSilentype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B5CB92136F0B6C007A7BED /* AppleSilentype.cpp */; };
-		00B6A2DF15B1FC97005E7A5C /* DIDDLDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B6A2DD15B1FC97005E7A5C /* DIDDLDiskStorage.cpp */; };
-		00B6A2E015B1FC97005E7A5C /* DIDDLDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B6A2DE15B1FC97005E7A5C /* DIDDLDiskStorage.h */; };
-		00B7C646147B4B4100BB7E6B /* JoystickMapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B7C645147B4B4100BB7E6B /* JoystickMapper.cpp */; };
-		00B7C64A147B5B2B00BB7E6B /* AppleIIGamePort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B7C649147B5B2B00BB7E6B /* AppleIIGamePort.cpp */; };
-		00B974B410701DDA00BD1402 /* sounds in Resources */ = {isa = PBXBuildFile; fileRef = 00B974AD10701DCD00BD1402 /* sounds */; };
-		00BB34B412C5C5AE007332B5 /* EmulationItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 00BB34B312C5C5AE007332B5 /* EmulationItem.mm */; };
-		00BDB1F713863188004DF2AF /* CanvasPrintView.m in Sources */ = {isa = PBXBuildFile; fileRef = 00BDB1F613863188004DF2AF /* CanvasPrintView.m */; };
-		00C6C0C110602151004D084B /* roms in Resources */ = {isa = PBXBuildFile; fileRef = 00C6C08810602151004D084B /* roms */; };
-		00CAD7D912A04C22002B92E5 /* Emulation.xib in Resources */ = {isa = PBXBuildFile; fileRef = 00CAD7D712A04C22002B92E5 /* Emulation.xib */; };
-		00CF208015B0D92200DA8E08 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00CF206F15B0D8C600DA8E08 /* util.cpp */; };
-		00CF208115B0D92600DA8E08 /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = 00CF207015B0D8C600DA8E08 /* util.h */; };
 		00CF208215B0DB5700DA8E08 /* libutil.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CF207615B0D8D300DA8E08 /* libutil.a */; };
-		00D6729D12C9A256009F0D9E /* EmulationShow.png in Resources */ = {isa = PBXBuildFile; fileRef = 00E442931278727600713A05 /* EmulationShow.png */; };
-		00D75C691399FFDB004AA153 /* LibraryTableCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D75C681399FFD9004AA153 /* LibraryTableCell.m */; };
-		00D7E410158D1E4B00EBF8FA /* AddressMasker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00D7E40E158D1E4B00EBF8FA /* AddressMasker.cpp */; };
-		00D8448B0FFF04C0005802F0 /* DiskImage.icns in Resources */ = {isa = PBXBuildFile; fileRef = 000F66370FF8368F00C8AF23 /* DiskImage.icns */; };
-		00D8448F0FFF04C0005802F0 /* Emulation.icns in Resources */ = {isa = PBXBuildFile; fileRef = 000F663A0FF8368F00C8AF23 /* Emulation.icns */; };
-		00D844A90FFF04C0005802F0 /* OpenEmulator.icns in Resources */ = {isa = PBXBuildFile; fileRef = 000F66520FF8368F00C8AF23 /* OpenEmulator.icns */; };
-		00D844B20FFF04C0005802F0 /* templates in Resources */ = {isa = PBXBuildFile; fileRef = 005928540FFC94E200F24A57 /* templates */; };
-		00D844C90FFF0505005802F0 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 00D844BD0FFF0505005802F0 /* MainMenu.xib */; };
-		00D844CC0FFF0505005802F0 /* Preferences.xib in Resources */ = {isa = PBXBuildFile; fileRef = 00D844C30FFF0505005802F0 /* Preferences.xib */; };
-		00D845830FFF0FD2005802F0 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D845730FFF0FD2005802F0 /* main.m */; };
-		00D845860FFF0FD2005802F0 /* PreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D8457A0FFF0FD2005802F0 /* PreferencesWindowController.m */; };
-		00D96F4C15E010AD0066EB0C /* AppleIIIKeyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00D96F4B15E010AD0066EB0C /* AppleIIIKeyboard.cpp */; };
-		00E442921278726B00713A05 /* IconDevices.png in Resources */ = {isa = PBXBuildFile; fileRef = 00E442911278726B00713A05 /* IconDevices.png */; };
-		00EA1F0515976F0200079A54 /* ATADevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00EA1F0315976F0200079A54 /* ATADevice.cpp */; };
-		00EA1F0615976F0200079A54 /* ATADevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 00EA1F0415976F0200079A54 /* ATADevice.h */; };
-		00EA1F0A159799C400079A54 /* RDCFFA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00EA1F08159799C400079A54 /* RDCFFA.cpp */; };
-		00EA1F0B159799C400079A54 /* RDCFFA.h in Headers */ = {isa = PBXBuildFile; fileRef = 00EA1F09159799C400079A54 /* RDCFFA.h */; };
-		00ED379C12779AD100BEF6BD /* AudioMax.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED379712779AD000BEF6BD /* AudioMax.png */; };
-		00ED379D12779AD100BEF6BD /* AudioMin.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED379812779AD000BEF6BD /* AudioMin.png */; };
-		00ED379E12779AD100BEF6BD /* AudioPlay.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED379912779AD000BEF6BD /* AudioPlay.png */; };
-		00ED37A012779AD100BEF6BD /* AudioStop.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED379B12779AD000BEF6BD /* AudioStop.png */; };
-		00ED37B912779DD900BEF6BD /* IconAudio.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37A812779DD800BEF6BD /* IconAudio.png */; };
-		00ED37BA12779DD900BEF6BD /* IconColdRestart.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37A912779DD800BEF6BD /* IconColdRestart.png */; };
-		00ED37BB12779DD900BEF6BD /* IconDebuggerBreak.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37AA12779DD800BEF6BD /* IconDebuggerBreak.png */; };
-		00ED37BC12779DD900BEF6BD /* IconGeneral.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37AB12779DD800BEF6BD /* IconGeneral.png */; };
-		00ED37BD12779DD900BEF6BD /* IconInspector.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37AC12779DD800BEF6BD /* IconInspector.png */; };
-		00ED37BE12779DD900BEF6BD /* IconPowerDown.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37AD12779DD800BEF6BD /* IconPowerDown.png */; };
-		00ED37BF12779DD900BEF6BD /* IconSleep.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37AE12779DD800BEF6BD /* IconSleep.png */; };
-		00ED37C012779DD900BEF6BD /* IconVideo.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37AF12779DD800BEF6BD /* IconVideo.png */; };
-		00ED37C112779DD900BEF6BD /* IconWakeUp.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37B012779DD800BEF6BD /* IconWakeUp.png */; };
-		00ED37C212779DD900BEF6BD /* IconWarmRestart.png in Resources */ = {isa = PBXBuildFile; fileRef = 00ED37B112779DD800BEF6BD /* IconWarmRestart.png */; };
-		00F01B4712A0D6EC000527CA /* EmulationUnmount.png in Resources */ = {isa = PBXBuildFile; fileRef = 00F01B4612A0D6EC000527CA /* EmulationUnmount.png */; };
-		00F21CE712C7C7EE00A809EF /* VerticallyCenteredTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 00F21CE612C7C7EE00A809EF /* VerticallyCenteredTextFieldCell.m */; };
-		00F2796F15B671E600E58F4F /* MOS6522.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00F2796E15B671E600E58F4F /* MOS6522.cpp */; };
-		00F2797215B671EE00E58F4F /* MOS6522.h in Headers */ = {isa = PBXBuildFile; fileRef = 00F2797115B671EE00E58F4F /* MOS6522.h */; };
-		00F35D7312EF049B0027B9E4 /* EmulationOutlineView.m in Sources */ = {isa = PBXBuildFile; fileRef = 00FE381A12CA6790002B47B1 /* EmulationOutlineView.m */; };
-		00F397E4141655DA00C53A3E /* Apple1IO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00F397E3141655DA00C53A3E /* Apple1IO.cpp */; };
 		00F4D0BF12E2E42F00B7F5E6 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00F4D0BE12E2E42F00B7F5E6 /* ApplicationServices.framework */; };
-		00FC27D312D1070A0065E986 /* Apple1ACI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8881312A393990052B7A4 /* Apple1ACI.cpp */; };
-		00FC27DB12D1070A0065E986 /* AppleIIAudioOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8881B12A393990052B7A4 /* AppleIIAudioOut.cpp */; };
-		00FC27DF12D1070A0065E986 /* AppleIIFloatingBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8881F12A393990052B7A4 /* AppleIIFloatingBus.cpp */; };
-		00FC27E312D1070A0065E986 /* AppleIIKeyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8882312A393990052B7A4 /* AppleIIKeyboard.cpp */; };
-		00FC27E912D1070A0065E986 /* AppleIISlotController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8882912A393990052B7A4 /* AppleIISlotController.cpp */; };
-		00FC27EB12D1070A0065E986 /* AppleIIVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8882B12A393990052B7A4 /* AppleIIVideo.cpp */; };
-		00FC27EE12D1070A0065E986 /* AppleDiskDrive525.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00044CA212CE6FD400D26940 /* AppleDiskDrive525.cpp */; };
-		00FC27EF12D1070A0065E986 /* AddressDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8882E12A393990052B7A4 /* AddressDecoder.cpp */; };
-		00FC27F112D1070A0065E986 /* AddressOffset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8883012A393990052B7A4 /* AddressOffset.cpp */; };
-		00FC27F312D1070A0065E986 /* AudioCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8883212A393990052B7A4 /* AudioCodec.cpp */; };
-		00FC27F712D1070A0065E986 /* Monitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8883612A393990052B7A4 /* Monitor.cpp */; };
-		00FC27F912D1070A0065E986 /* ControlBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8883812A393990052B7A4 /* ControlBus.cpp */; };
-		00FC27FB12D1070A0065E986 /* FloatingBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8883A12A393990052B7A4 /* FloatingBus.cpp */; };
-		00FC27FD12D1070A0065E986 /* RAM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8883C12A393990052B7A4 /* RAM.cpp */; };
-		00FC27FF12D1070A0065E986 /* ROM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8883E12A393990052B7A4 /* ROM.cpp */; };
-		00FC280312D1070A0065E986 /* MOS6502.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8884312A393990052B7A4 /* MOS6502.cpp */; };
-		00FC280812D1070A0065E986 /* MOS6530.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8884C12A393990052B7A4 /* MOS6530.cpp */; };
-		00FC280A12D1070A0065E986 /* MOSKIM1IO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8884E12A393990052B7A4 /* MOSKIM1IO.cpp */; };
-		00FC280C12D1070A0065E986 /* MOSKIM1PLL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8885012A393990052B7A4 /* MOSKIM1PLL.cpp */; };
-		00FC280E12D1070A0065E986 /* MC6821.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8885312A393990052B7A4 /* MC6821.cpp */; };
-		00FC281012D1070A0065E986 /* MC6845.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8885512A393990052B7A4 /* MC6845.cpp */; };
+		496AF1DB18C677B600B35159 /* images in Resources */ = {isa = PBXBuildFile; fileRef = 496AF1D718C677B600B35159 /* images */; };
+		496AF1DC18C677B600B35159 /* library in Resources */ = {isa = PBXBuildFile; fileRef = 496AF1D818C677B600B35159 /* library */; };
+		496AF1DD18C677B600B35159 /* sounds in Resources */ = {isa = PBXBuildFile; fileRef = 496AF1D918C677B600B35159 /* sounds */; };
+		496AF1DE18C677B600B35159 /* templates in Resources */ = {isa = PBXBuildFile; fileRef = 496AF1DA18C677B600B35159 /* templates */; };
+		496AF1E018C746F300B35159 /* roms in Resources */ = {isa = PBXBuildFile; fileRef = 496AF1DF18C746F300B35159 /* roms */; };
+		49EB4C4318C63B1800AD682A /* libFLAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 49EB4C4218C63B1800AD682A /* libFLAC.dylib */; };
+		49EB4CB218C63BE500AD682A /* Application.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C4B18C63BE500AD682A /* Application.m */; };
+		49EB4CB318C63BE500AD682A /* AudioControlsWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C4D18C63BE500AD682A /* AudioControlsWindowController.mm */; };
+		49EB4CB418C63BE500AD682A /* BackgroundView.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C4F18C63BE500AD682A /* BackgroundView.m */; };
+		49EB4CB518C63BE500AD682A /* CanvasPrintView.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C5118C63BE500AD682A /* CanvasPrintView.m */; };
+		49EB4CB618C63BE500AD682A /* CanvasToolbarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C5318C63BE500AD682A /* CanvasToolbarView.m */; };
+		49EB4CB718C63BE500AD682A /* CanvasView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C5518C63BE500AD682A /* CanvasView.mm */; };
+		49EB4CB818C63BE500AD682A /* CanvasWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C5718C63BE500AD682A /* CanvasWindow.m */; };
+		49EB4CB918C63BE500AD682A /* CanvasWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C5918C63BE500AD682A /* CanvasWindowController.m */; };
+		49EB4CBA18C63BE500AD682A /* Document.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C5B18C63BE500AD682A /* Document.mm */; };
+		49EB4CBB18C63BE500AD682A /* DocumentController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C5D18C63BE500AD682A /* DocumentController.mm */; };
+		49EB4CBC18C63BE500AD682A /* EmulationItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C5F18C63BE500AD682A /* EmulationItem.mm */; };
+		49EB4CBD18C63BE500AD682A /* EmulationOutlineCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C6118C63BE500AD682A /* EmulationOutlineCell.m */; };
+		49EB4CBE18C63BE500AD682A /* EmulationOutlineView.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C6318C63BE500AD682A /* EmulationOutlineView.m */; };
+		49EB4CBF18C63BE500AD682A /* EmulationWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C6518C63BE500AD682A /* EmulationWindowController.m */; };
+		49EB4CC018C63BE500AD682A /* AudioControls.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C6618C63BE500AD682A /* AudioControls.xib */; };
+		49EB4CC118C63BE500AD682A /* Canvas.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C6818C63BE500AD682A /* Canvas.xib */; };
+		49EB4CC218C63BE500AD682A /* Emulation.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C6A18C63BE500AD682A /* Emulation.xib */; };
+		49EB4CC318C63BE500AD682A /* Library.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C6C18C63BE500AD682A /* Library.xib */; };
+		49EB4CC418C63BE500AD682A /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C6E18C63BE500AD682A /* MainMenu.xib */; };
+		49EB4CC518C63BE500AD682A /* Preferences.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7018C63BE500AD682A /* Preferences.xib */; };
+		49EB4CC618C63BE500AD682A /* TemplateChooser.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7218C63BE500AD682A /* TemplateChooser.xib */; };
+		49EB4CC718C63BE500AD682A /* TemplateChooserView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7418C63BE500AD682A /* TemplateChooserView.xib */; };
+		49EB4CC818C63BE500AD682A /* AudioMax.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7718C63BE500AD682A /* AudioMax.png */; };
+		49EB4CC918C63BE500AD682A /* AudioMin.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7818C63BE500AD682A /* AudioMin.png */; };
+		49EB4CCA18C63BE500AD682A /* AudioPause.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7918C63BE500AD682A /* AudioPause.png */; };
+		49EB4CCB18C63BE500AD682A /* AudioPlay.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7A18C63BE500AD682A /* AudioPlay.png */; };
+		49EB4CCC18C63BE500AD682A /* AudioRecord.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7B18C63BE500AD682A /* AudioRecord.png */; };
+		49EB4CCD18C63BE500AD682A /* AudioStop.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7C18C63BE500AD682A /* AudioStop.png */; };
+		49EB4CCE18C63BE500AD682A /* DiskImage.icns in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7D18C63BE500AD682A /* DiskImage.icns */; };
+		49EB4CCF18C63BE500AD682A /* Emulation.icns in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7E18C63BE500AD682A /* Emulation.icns */; };
+		49EB4CD018C63BE500AD682A /* EmulationShow.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C7F18C63BE500AD682A /* EmulationShow.png */; };
+		49EB4CD118C63BE500AD682A /* EmulationShowPressed.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8018C63BE500AD682A /* EmulationShowPressed.png */; };
+		49EB4CD218C63BE500AD682A /* EmulationShowRollover.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8118C63BE500AD682A /* EmulationShowRollover.png */; };
+		49EB4CD318C63BE500AD682A /* EmulationShowSelected.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8218C63BE500AD682A /* EmulationShowSelected.png */; };
+		49EB4CD418C63BE500AD682A /* EmulationUnmount.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8318C63BE500AD682A /* EmulationUnmount.png */; };
+		49EB4CD518C63BE500AD682A /* EmulationUnmountPressed.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8418C63BE500AD682A /* EmulationUnmountPressed.png */; };
+		49EB4CD618C63BE500AD682A /* EmulationUnmountRollover.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8518C63BE500AD682A /* EmulationUnmountRollover.png */; };
+		49EB4CD718C63BE500AD682A /* EmulationUnmountSelected.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8618C63BE500AD682A /* EmulationUnmountSelected.png */; };
+		49EB4CD818C63BE500AD682A /* IconAudio.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8718C63BE500AD682A /* IconAudio.png */; };
+		49EB4CD918C63BE500AD682A /* IconColdRestart.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8818C63BE500AD682A /* IconColdRestart.png */; };
+		49EB4CDA18C63BE500AD682A /* IconDebuggerBreak.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8918C63BE500AD682A /* IconDebuggerBreak.png */; };
+		49EB4CDB18C63BE500AD682A /* IconDevices.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8A18C63BE500AD682A /* IconDevices.png */; };
+		49EB4CDC18C63BE500AD682A /* IconGeneral.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8B18C63BE500AD682A /* IconGeneral.png */; };
+		49EB4CDD18C63BE500AD682A /* IconInspector.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8C18C63BE500AD682A /* IconInspector.png */; };
+		49EB4CDE18C63BE500AD682A /* IconLibrary.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8D18C63BE500AD682A /* IconLibrary.png */; };
+		49EB4CDF18C63BE500AD682A /* IconPowerDown.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8E18C63BE500AD682A /* IconPowerDown.png */; };
+		49EB4CE018C63BE500AD682A /* IconRevert.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C8F18C63BE500AD682A /* IconRevert.png */; };
+		49EB4CE118C63BE500AD682A /* IconSleep.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C9018C63BE500AD682A /* IconSleep.png */; };
+		49EB4CE218C63BE500AD682A /* IconVideo.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C9118C63BE500AD682A /* IconVideo.png */; };
+		49EB4CE318C63BE500AD682A /* IconWakeUp.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C9218C63BE500AD682A /* IconWakeUp.png */; };
+		49EB4CE418C63BE500AD682A /* IconWarmRestart.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C9318C63BE500AD682A /* IconWarmRestart.png */; };
+		49EB4CE518C63BE500AD682A /* OpenEmulator.icns in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C9418C63BE500AD682A /* OpenEmulator.icns */; };
+		49EB4CE618C63BE500AD682A /* ToolbarBackground.png in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4C9518C63BE500AD682A /* ToolbarBackground.png */; };
+		49EB4CE818C63BE500AD682A /* LibraryItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C9818C63BE500AD682A /* LibraryItem.mm */; };
+		49EB4CE918C63BE500AD682A /* LibraryTableCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C9A18C63BE500AD682A /* LibraryTableCell.m */; };
+		49EB4CEA18C63BE500AD682A /* LibraryTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C9C18C63BE500AD682A /* LibraryTableView.m */; };
+		49EB4CEB18C63BE500AD682A /* LibraryWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C9E18C63BE500AD682A /* LibraryWindowController.m */; };
+		49EB4CEC18C63BE500AD682A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4C9F18C63BE500AD682A /* main.m */; };
+		49EB4CED18C63BE500AD682A /* NSStringAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4CA118C63BE500AD682A /* NSStringAdditions.mm */; };
+		49EB4CEE18C63BE500AD682A /* PreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4CA418C63BE500AD682A /* PreferencesWindowController.m */; };
+		49EB4CF018C63BE500AD682A /* sparkle_dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4CA618C63BE500AD682A /* sparkle_dsa_pub.pem */; };
+		49EB4CF118C63BE500AD682A /* TemplateChooserItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4CA818C63BE500AD682A /* TemplateChooserItem.mm */; };
+		49EB4CF218C63BE500AD682A /* TemplateChooserViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4CAA18C63BE500AD682A /* TemplateChooserViewController.m */; };
+		49EB4CF318C63BE500AD682A /* TemplateChooserWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4CAC18C63BE500AD682A /* TemplateChooserWindowController.m */; };
+		49EB4CF418C63BE500AD682A /* VerticallyCenteredTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4CAE18C63BE500AD682A /* VerticallyCenteredTextFieldCell.m */; };
+		49EB4D0718C6536100AD682A /* AudioControls.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4CF718C6536000AD682A /* AudioControls.xib */; };
+		49EB4D0818C6536100AD682A /* Canvas.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4CF918C6536000AD682A /* Canvas.xib */; };
+		49EB4D0918C6536100AD682A /* Emulation.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4CFB18C6536000AD682A /* Emulation.xib */; };
+		49EB4D0A18C6536100AD682A /* Library.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4CFD18C6536000AD682A /* Library.xib */; };
+		49EB4D0B18C6536100AD682A /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4CFF18C6536000AD682A /* MainMenu.xib */; };
+		49EB4D0C18C6536100AD682A /* Preferences.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4D0118C6536000AD682A /* Preferences.xib */; };
+		49EB4D0D18C6536100AD682A /* TemplateChooser.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4D0318C6536100AD682A /* TemplateChooser.xib */; };
+		49EB4D0E18C6536100AD682A /* TemplateChooserView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49EB4D0518C6536100AD682A /* TemplateChooserView.xib */; };
+		49EB4D1418C65CD500AD682A /* libpng16.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 49EB4D1318C65CD500AD682A /* libpng16.a */; };
+		49EB4D1518C65CD500AD682A /* libpng16.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 49EB4D1318C65CD500AD682A /* libpng16.a */; };
+		49EB4D4B18C66FDD00AD682A /* DI2IMGBackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D2618C66FDD00AD682A /* DI2IMGBackingStore.cpp */; };
+		49EB4D4C18C66FDD00AD682A /* DI2IMGBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D2718C66FDD00AD682A /* DI2IMGBackingStore.h */; };
+		49EB4D4D18C66FDD00AD682A /* DIApple35DiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D2818C66FDD00AD682A /* DIApple35DiskStorage.cpp */; };
+		49EB4D4E18C66FDD00AD682A /* DIApple35DiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D2918C66FDD00AD682A /* DIApple35DiskStorage.h */; };
+		49EB4D4F18C66FDD00AD682A /* DIApple525DiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D2A18C66FDD00AD682A /* DIApple525DiskStorage.cpp */; };
+		49EB4D5018C66FDD00AD682A /* DIApple525DiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D2B18C66FDD00AD682A /* DIApple525DiskStorage.h */; };
+		49EB4D5118C66FDD00AD682A /* DIATABlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D2C18C66FDD00AD682A /* DIATABlockStorage.cpp */; };
+		49EB4D5218C66FDD00AD682A /* DIATABlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D2D18C66FDD00AD682A /* DIATABlockStorage.h */; };
+		49EB4D5318C66FDD00AD682A /* DIBackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D2E18C66FDD00AD682A /* DIBackingStore.cpp */; };
+		49EB4D5418C66FDD00AD682A /* DIBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D2F18C66FDD00AD682A /* DIBackingStore.h */; };
+		49EB4D5518C66FDD00AD682A /* DIBlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D3018C66FDD00AD682A /* DIBlockStorage.cpp */; };
+		49EB4D5618C66FDD00AD682A /* DIBlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D3118C66FDD00AD682A /* DIBlockStorage.h */; };
+		49EB4D5718C66FDD00AD682A /* DICommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D3218C66FDD00AD682A /* DICommon.cpp */; };
+		49EB4D5818C66FDD00AD682A /* DICommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D3318C66FDD00AD682A /* DICommon.h */; };
+		49EB4D5918C66FDD00AD682A /* DIDC42BackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D3418C66FDD00AD682A /* DIDC42BackingStore.cpp */; };
+		49EB4D5A18C66FDD00AD682A /* DIDC42BackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D3518C66FDD00AD682A /* DIDC42BackingStore.h */; };
+		49EB4D5B18C66FDD00AD682A /* DIDDLDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D3618C66FDD00AD682A /* DIDDLDiskStorage.cpp */; };
+		49EB4D5C18C66FDD00AD682A /* DIDDLDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D3718C66FDD00AD682A /* DIDDLDiskStorage.h */; };
+		49EB4D5D18C66FDD00AD682A /* DIDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D3818C66FDD00AD682A /* DIDiskStorage.cpp */; };
+		49EB4D5E18C66FDD00AD682A /* DIDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D3918C66FDD00AD682A /* DIDiskStorage.h */; };
+		49EB4D5F18C66FDD00AD682A /* DIFDIDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D3A18C66FDD00AD682A /* DIFDIDiskStorage.cpp */; };
+		49EB4D6018C66FDD00AD682A /* DIFDIDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D3B18C66FDD00AD682A /* DIFDIDiskStorage.h */; };
+		49EB4D6118C66FDD00AD682A /* DIFileBackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D3C18C66FDD00AD682A /* DIFileBackingStore.cpp */; };
+		49EB4D6218C66FDD00AD682A /* DIFileBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D3D18C66FDD00AD682A /* DIFileBackingStore.h */; };
+		49EB4D6318C66FDD00AD682A /* DILogicalDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D3E18C66FDD00AD682A /* DILogicalDiskStorage.cpp */; };
+		49EB4D6418C66FDD00AD682A /* DILogicalDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D3F18C66FDD00AD682A /* DILogicalDiskStorage.h */; };
+		49EB4D6518C66FDD00AD682A /* DIRAMBackingStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D4018C66FDD00AD682A /* DIRAMBackingStore.cpp */; };
+		49EB4D6618C66FDD00AD682A /* DIRAMBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D4118C66FDD00AD682A /* DIRAMBackingStore.h */; };
+		49EB4D6718C66FDD00AD682A /* DIRAWBlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D4218C66FDD00AD682A /* DIRAWBlockStorage.cpp */; };
+		49EB4D6818C66FDD00AD682A /* DIRAWBlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D4318C66FDD00AD682A /* DIRAWBlockStorage.h */; };
+		49EB4D6918C66FDD00AD682A /* diskimage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D4418C66FDD00AD682A /* diskimage.h */; };
+		49EB4D6A18C66FDD00AD682A /* DIV2DDiskStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D4518C66FDD00AD682A /* DIV2DDiskStorage.cpp */; };
+		49EB4D6B18C66FDD00AD682A /* DIV2DDiskStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D4618C66FDD00AD682A /* DIV2DDiskStorage.h */; };
+		49EB4D6C18C66FDD00AD682A /* DIVDIBlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D4718C66FDD00AD682A /* DIVDIBlockStorage.cpp */; };
+		49EB4D6D18C66FDD00AD682A /* DIVDIBlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D4818C66FDD00AD682A /* DIVDIBlockStorage.h */; };
+		49EB4D6E18C66FDD00AD682A /* DIVMDKBlockStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D4918C66FDD00AD682A /* DIVMDKBlockStorage.cpp */; };
+		49EB4D6F18C66FDD00AD682A /* DIVMDKBlockStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D4A18C66FDD00AD682A /* DIVMDKBlockStorage.h */; };
+		49EB4E3918C6702200AD682A /* OECommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D7118C6702100AD682A /* OECommon.cpp */; };
+		49EB4E3A18C6702200AD682A /* OECommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D7218C6702100AD682A /* OECommon.h */; };
+		49EB4E3B18C6702200AD682A /* OEComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D7318C6702100AD682A /* OEComponent.cpp */; };
+		49EB4E3C18C6702200AD682A /* OEComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D7418C6702100AD682A /* OEComponent.h */; };
+		49EB4E3D18C6702200AD682A /* OEComponentFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D7518C6702100AD682A /* OEComponentFactory.cpp */; };
+		49EB4E3E18C6702200AD682A /* OEComponentFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D7618C6702100AD682A /* OEComponentFactory.h */; };
+		49EB4E3F18C6702200AD682A /* OEDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D7718C6702100AD682A /* OEDevice.cpp */; };
+		49EB4E4018C6702200AD682A /* OEDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D7818C6702100AD682A /* OEDevice.h */; };
+		49EB4E4118C6702200AD682A /* OEDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D7918C6702100AD682A /* OEDocument.cpp */; };
+		49EB4E4218C6702200AD682A /* OEDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D7A18C6702100AD682A /* OEDocument.h */; };
+		49EB4E4318C6702200AD682A /* OEEmulation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D7B18C6702100AD682A /* OEEmulation.cpp */; };
+		49EB4E4418C6702200AD682A /* OEEmulation.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D7C18C6702100AD682A /* OEEmulation.h */; };
+		49EB4E4518C6702200AD682A /* OEImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D7D18C6702100AD682A /* OEImage.cpp */; };
+		49EB4E4618C6702200AD682A /* OEImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D7E18C6702100AD682A /* OEImage.h */; };
+		49EB4E4718C6702200AD682A /* OEPackage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D7F18C6702100AD682A /* OEPackage.cpp */; };
+		49EB4E4818C6702200AD682A /* OEPackage.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D8018C6702100AD682A /* OEPackage.h */; };
+		49EB4E4918C6702200AD682A /* OESound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D8118C6702100AD682A /* OESound.cpp */; };
+		49EB4E4A18C6702200AD682A /* OESound.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D8218C6702100AD682A /* OESound.h */; };
+		49EB4E4B18C6702200AD682A /* Apple1ACI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D8718C6702100AD682A /* Apple1ACI.cpp */; };
+		49EB4E4C18C6702200AD682A /* Apple1ACI.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D8818C6702100AD682A /* Apple1ACI.h */; };
+		49EB4E4D18C6702200AD682A /* Apple1IO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D8918C6702100AD682A /* Apple1IO.cpp */; };
+		49EB4E4E18C6702200AD682A /* Apple1IO.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D8A18C6702100AD682A /* Apple1IO.h */; };
+		49EB4E4F18C6702200AD682A /* Apple1Terminal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D8B18C6702100AD682A /* Apple1Terminal.cpp */; };
+		49EB4E5018C6702200AD682A /* Apple1Terminal.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D8C18C6702100AD682A /* Apple1Terminal.h */; };
+		49EB4E5118C6702200AD682A /* AppleDiskDrive525.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D8D18C6702100AD682A /* AppleDiskDrive525.cpp */; };
+		49EB4E5218C6702200AD682A /* AppleDiskDrive525.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D8E18C6702100AD682A /* AppleDiskDrive525.h */; };
+		49EB4E5318C6702200AD682A /* AppleDiskIIInterfaceCard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D8F18C6702100AD682A /* AppleDiskIIInterfaceCard.cpp */; };
+		49EB4E5418C6702200AD682A /* AppleDiskIIInterfaceCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D9018C6702100AD682A /* AppleDiskIIInterfaceCard.h */; };
+		49EB4E5518C6702200AD682A /* AppleGraphicsTablet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D9118C6702100AD682A /* AppleGraphicsTablet.cpp */; };
+		49EB4E5618C6702200AD682A /* AppleGraphicsTablet.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D9218C6702100AD682A /* AppleGraphicsTablet.h */; };
+		49EB4E5718C6702200AD682A /* AppleGraphicsTabletInterfaceCard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D9318C6702100AD682A /* AppleGraphicsTabletInterfaceCard.cpp */; };
+		49EB4E5818C6702200AD682A /* AppleGraphicsTabletInterfaceCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D9418C6702100AD682A /* AppleGraphicsTabletInterfaceCard.h */; };
+		49EB4E5918C6702200AD682A /* AppleIIAddressDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D9518C6702100AD682A /* AppleIIAddressDecoder.cpp */; };
+		49EB4E5A18C6702200AD682A /* AppleIIAddressDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D9618C6702100AD682A /* AppleIIAddressDecoder.h */; };
+		49EB4E5B18C6702200AD682A /* AppleIIAudioIn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D9718C6702100AD682A /* AppleIIAudioIn.cpp */; };
+		49EB4E5C18C6702200AD682A /* AppleIIAudioIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D9818C6702100AD682A /* AppleIIAudioIn.h */; };
+		49EB4E5D18C6702200AD682A /* AppleIIAudioOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D9918C6702100AD682A /* AppleIIAudioOut.cpp */; };
+		49EB4E5E18C6702200AD682A /* AppleIIAudioOut.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D9A18C6702100AD682A /* AppleIIAudioOut.h */; };
+		49EB4E5F18C6702200AD682A /* AppleIIDisableC800.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D9B18C6702100AD682A /* AppleIIDisableC800.cpp */; };
+		49EB4E6018C6702200AD682A /* AppleIIDisableC800.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D9C18C6702100AD682A /* AppleIIDisableC800.h */; };
+		49EB4E6118C6702200AD682A /* AppleIIFloatingBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D9D18C6702100AD682A /* AppleIIFloatingBus.cpp */; };
+		49EB4E6218C6702200AD682A /* AppleIIFloatingBus.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4D9E18C6702100AD682A /* AppleIIFloatingBus.h */; };
+		49EB4E6318C6702200AD682A /* AppleIIGamePort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4D9F18C6702100AD682A /* AppleIIGamePort.cpp */; };
+		49EB4E6418C6702200AD682A /* AppleIIGamePort.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DA018C6702100AD682A /* AppleIIGamePort.h */; };
+		49EB4E6518C6702200AD682A /* AppleIIIAddressDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DA118C6702100AD682A /* AppleIIIAddressDecoder.cpp */; };
+		49EB4E6618C6702200AD682A /* AppleIIIAddressDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DA218C6702100AD682A /* AppleIIIAddressDecoder.h */; };
+		49EB4E6718C6702200AD682A /* AppleIIIBeeper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DA318C6702100AD682A /* AppleIIIBeeper.cpp */; };
+		49EB4E6818C6702200AD682A /* AppleIIIBeeper.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DA418C6702100AD682A /* AppleIIIBeeper.h */; };
+		49EB4E6918C6702200AD682A /* AppleIIIDiskIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DA518C6702100AD682A /* AppleIIIDiskIO.cpp */; };
+		49EB4E6A18C6702200AD682A /* AppleIIIDiskIO.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DA618C6702100AD682A /* AppleIIIDiskIO.h */; };
+		49EB4E6B18C6702200AD682A /* AppleIIIGamePort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DA718C6702100AD682A /* AppleIIIGamePort.cpp */; };
+		49EB4E6C18C6702200AD682A /* AppleIIIGamePort.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DA818C6702100AD682A /* AppleIIIGamePort.h */; };
+		49EB4E6D18C6702200AD682A /* AppleIIIKeyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DA918C6702100AD682A /* AppleIIIKeyboard.cpp */; };
+		49EB4E6E18C6702200AD682A /* AppleIIIKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DAA18C6702100AD682A /* AppleIIIKeyboard.h */; };
+		49EB4E6F18C6702200AD682A /* AppleIIIMOS6502.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DAB18C6702100AD682A /* AppleIIIMOS6502.cpp */; };
+		49EB4E7018C6702200AD682A /* AppleIIIMOS6502.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DAC18C6702100AD682A /* AppleIIIMOS6502.h */; };
+		49EB4E7118C6702200AD682A /* AppleIIIMOS6502Opcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DAD18C6702100AD682A /* AppleIIIMOS6502Opcodes.h */; };
+		49EB4E7218C6702200AD682A /* AppleIIIMOS6502Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DAE18C6702100AD682A /* AppleIIIMOS6502Operations.h */; };
+		49EB4E7318C6702200AD682A /* AppleIIIRTC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DAF18C6702100AD682A /* AppleIIIRTC.cpp */; };
+		49EB4E7418C6702200AD682A /* AppleIIIRTC.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DB018C6702100AD682A /* AppleIIIRTC.h */; };
+		49EB4E7518C6702200AD682A /* AppleIIISystemControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DB118C6702100AD682A /* AppleIIISystemControl.cpp */; };
+		49EB4E7618C6702200AD682A /* AppleIIISystemControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DB218C6702100AD682A /* AppleIIISystemControl.h */; };
+		49EB4E7718C6702200AD682A /* AppleIIIVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DB318C6702100AD682A /* AppleIIIVideo.cpp */; };
+		49EB4E7818C6702200AD682A /* AppleIIIVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DB418C6702100AD682A /* AppleIIIVideo.h */; };
+		49EB4E7918C6702200AD682A /* AppleIIKeyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DB518C6702100AD682A /* AppleIIKeyboard.cpp */; };
+		49EB4E7A18C6702200AD682A /* AppleIIKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DB618C6702100AD682A /* AppleIIKeyboard.h */; };
+		49EB4E7B18C6702200AD682A /* AppleIISlotController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DB718C6702100AD682A /* AppleIISlotController.cpp */; };
+		49EB4E7C18C6702200AD682A /* AppleIISlotController.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DB818C6702100AD682A /* AppleIISlotController.h */; };
+		49EB4E7D18C6702200AD682A /* AppleIISystemControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DB918C6702100AD682A /* AppleIISystemControl.cpp */; };
+		49EB4E7E18C6702200AD682A /* AppleIISystemControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DBA18C6702100AD682A /* AppleIISystemControl.h */; };
+		49EB4E7F18C6702200AD682A /* AppleIIVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DBB18C6702100AD682A /* AppleIIVideo.cpp */; };
+		49EB4E8018C6702200AD682A /* AppleIIVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DBC18C6702100AD682A /* AppleIIVideo.h */; };
+		49EB4E8118C6702200AD682A /* AppleLanguageCard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DBD18C6702100AD682A /* AppleLanguageCard.cpp */; };
+		49EB4E8218C6702200AD682A /* AppleLanguageCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DBE18C6702100AD682A /* AppleLanguageCard.h */; };
+		49EB4E8318C6702200AD682A /* AppleSilentype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DBF18C6702100AD682A /* AppleSilentype.cpp */; };
+		49EB4E8418C6702200AD682A /* AppleSilentype.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DC018C6702100AD682A /* AppleSilentype.h */; };
+		49EB4E8518C6702200AD682A /* AppleSilentypeInterfaceCard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DC118C6702100AD682A /* AppleSilentypeInterfaceCard.cpp */; };
+		49EB4E8618C6702200AD682A /* AppleSilentypeInterfaceCard.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DC218C6702100AD682A /* AppleSilentypeInterfaceCard.h */; };
+		49EB4E8718C6702200AD682A /* AddressDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DC418C6702100AD682A /* AddressDecoder.cpp */; };
+		49EB4E8818C6702200AD682A /* AddressDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DC518C6702100AD682A /* AddressDecoder.h */; };
+		49EB4E8918C6702200AD682A /* AddressMapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DC618C6702100AD682A /* AddressMapper.cpp */; };
+		49EB4E8A18C6702200AD682A /* AddressMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DC718C6702100AD682A /* AddressMapper.h */; };
+		49EB4E8B18C6702200AD682A /* AddressMasker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DC818C6702100AD682A /* AddressMasker.cpp */; };
+		49EB4E8C18C6702200AD682A /* AddressMasker.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DC918C6702100AD682A /* AddressMasker.h */; };
+		49EB4E8D18C6702200AD682A /* AddressMux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DCA18C6702100AD682A /* AddressMux.cpp */; };
+		49EB4E8E18C6702200AD682A /* AddressMux.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DCB18C6702100AD682A /* AddressMux.h */; };
+		49EB4E8F18C6702200AD682A /* AddressOffset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DCC18C6702100AD682A /* AddressOffset.cpp */; };
+		49EB4E9018C6702200AD682A /* AddressOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DCD18C6702100AD682A /* AddressOffset.h */; };
+		49EB4E9118C6702200AD682A /* ATAController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DCE18C6702100AD682A /* ATAController.cpp */; };
+		49EB4E9218C6702200AD682A /* ATAController.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DCF18C6702100AD682A /* ATAController.h */; };
+		49EB4E9318C6702200AD682A /* ATADevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DD018C6702200AD682A /* ATADevice.cpp */; };
+		49EB4E9418C6702200AD682A /* ATADevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DD118C6702200AD682A /* ATADevice.h */; };
+		49EB4E9518C6702200AD682A /* Audio1Bit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DD218C6702200AD682A /* Audio1Bit.cpp */; };
+		49EB4E9618C6702200AD682A /* Audio1Bit.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DD318C6702200AD682A /* Audio1Bit.h */; };
+		49EB4E9718C6702200AD682A /* AudioCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DD418C6702200AD682A /* AudioCodec.cpp */; };
+		49EB4E9818C6702200AD682A /* AudioCodec.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DD518C6702200AD682A /* AudioCodec.h */; };
+		49EB4E9918C6702200AD682A /* AudioPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DD618C6702200AD682A /* AudioPlayer.cpp */; };
+		49EB4E9A18C6702200AD682A /* AudioPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DD718C6702200AD682A /* AudioPlayer.h */; };
+		49EB4E9B18C6702200AD682A /* ControlBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DD818C6702200AD682A /* ControlBus.cpp */; };
+		49EB4E9C18C6702200AD682A /* ControlBus.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DD918C6702200AD682A /* ControlBus.h */; };
+		49EB4E9D18C6702200AD682A /* FloatingBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DDA18C6702200AD682A /* FloatingBus.cpp */; };
+		49EB4E9E18C6702200AD682A /* FloatingBus.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DDB18C6702200AD682A /* FloatingBus.h */; };
+		49EB4E9F18C6702200AD682A /* JoystickMapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DDC18C6702200AD682A /* JoystickMapper.cpp */; };
+		49EB4EA018C6702200AD682A /* JoystickMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DDD18C6702200AD682A /* JoystickMapper.h */; };
+		49EB4EA118C6702200AD682A /* Monitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DDE18C6702200AD682A /* Monitor.cpp */; };
+		49EB4EA218C6702200AD682A /* Monitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DDF18C6702200AD682A /* Monitor.h */; };
+		49EB4EA318C6702200AD682A /* Proxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DE018C6702200AD682A /* Proxy.cpp */; };
+		49EB4EA418C6702200AD682A /* Proxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DE118C6702200AD682A /* Proxy.h */; };
+		49EB4EA518C6702200AD682A /* RAM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DE218C6702200AD682A /* RAM.cpp */; };
+		49EB4EA618C6702200AD682A /* RAM.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DE318C6702200AD682A /* RAM.h */; };
+		49EB4EA718C6702200AD682A /* ROM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DE418C6702200AD682A /* ROM.cpp */; };
+		49EB4EA818C6702200AD682A /* ROM.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DE518C6702200AD682A /* ROM.h */; };
+		49EB4EA918C6702200AD682A /* VRAM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DE618C6702200AD682A /* VRAM.cpp */; };
+		49EB4EAA18C6702200AD682A /* VRAM.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DE718C6702200AD682A /* VRAM.h */; };
+		49EB4EAB18C6702200AD682A /* MOS6502.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DE918C6702200AD682A /* MOS6502.cpp */; };
+		49EB4EAC18C6702200AD682A /* MOS6502.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DEA18C6702200AD682A /* MOS6502.h */; };
+		49EB4EAD18C6702200AD682A /* MOS6502IllegalOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DEB18C6702200AD682A /* MOS6502IllegalOperations.h */; };
+		49EB4EAE18C6702200AD682A /* MOS6502Opcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DEC18C6702200AD682A /* MOS6502Opcodes.h */; };
+		49EB4EAF18C6702200AD682A /* MOS6502Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DED18C6702200AD682A /* MOS6502Operations.h */; };
+		49EB4EB418C6702200AD682A /* MOS6522.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DF218C6702200AD682A /* MOS6522.cpp */; };
+		49EB4EB518C6702200AD682A /* MOS6522.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DF318C6702200AD682A /* MOS6522.h */; };
+		49EB4EB618C6702200AD682A /* MOS6530.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DF418C6702200AD682A /* MOS6530.cpp */; };
+		49EB4EB718C6702200AD682A /* MOS6530.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DF518C6702200AD682A /* MOS6530.h */; };
+		49EB4EB818C6702200AD682A /* MOS6551.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DF618C6702200AD682A /* MOS6551.cpp */; };
+		49EB4EB918C6702200AD682A /* MOS6551.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DF718C6702200AD682A /* MOS6551.h */; };
+		49EB4EBA18C6702200AD682A /* MOSKIM1IO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DF818C6702200AD682A /* MOSKIM1IO.cpp */; };
+		49EB4EBB18C6702200AD682A /* MOSKIM1IO.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DF918C6702200AD682A /* MOSKIM1IO.h */; };
+		49EB4EBC18C6702200AD682A /* MOSKIM1PLL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DFA18C6702200AD682A /* MOSKIM1PLL.cpp */; };
+		49EB4EBD18C6702200AD682A /* MOSKIM1PLL.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DFB18C6702200AD682A /* MOSKIM1PLL.h */; };
+		49EB4EBE18C6702200AD682A /* MC6821.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DFD18C6702200AD682A /* MC6821.cpp */; };
+		49EB4EBF18C6702200AD682A /* MC6821.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4DFE18C6702200AD682A /* MC6821.h */; };
+		49EB4EC018C6702200AD682A /* MC6845.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4DFF18C6702200AD682A /* MC6845.cpp */; };
+		49EB4EC118C6702200AD682A /* MC6845.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E0018C6702200AD682A /* MC6845.h */; };
+		49EB4EC218C6702200AD682A /* MM58167.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4E0218C6702200AD682A /* MM58167.cpp */; };
+		49EB4EC318C6702200AD682A /* MM58167.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E0318C6702200AD682A /* MM58167.h */; };
+		49EB4EC418C6702200AD682A /* RDCFFA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4E0518C6702200AD682A /* RDCFFA.cpp */; };
+		49EB4EC518C6702200AD682A /* RDCFFA.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E0618C6702200AD682A /* RDCFFA.h */; };
+		49EB4ECB18C6702200AD682A /* VidexVideoterm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4E0E18C6702200AD682A /* VidexVideoterm.cpp */; };
+		49EB4ECC18C6702200AD682A /* VidexVideoterm.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E0F18C6702200AD682A /* VidexVideoterm.h */; };
+		49EB4ECD18C6702200AD682A /* W65C02S.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4E1118C6702200AD682A /* W65C02S.cpp */; };
+		49EB4ECE18C6702200AD682A /* W65C02S.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E1218C6702200AD682A /* W65C02S.h */; };
+		49EB4ECF18C6702200AD682A /* W65C02SOpcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E1318C6702200AD682A /* W65C02SOpcodes.h */; };
+		49EB4ED018C6702200AD682A /* W65C02SOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E1418C6702200AD682A /* W65C02SOperations.h */; };
+		49EB4ED118C6702200AD682A /* W65C816S.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4E1518C6702200AD682A /* W65C816S.cpp */; };
+		49EB4ED218C6702200AD682A /* W65C816S.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E1618C6702200AD682A /* W65C816S.h */; };
+		49EB4ED718C6702200AD682A /* AppleIIIInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E1E18C6702200AD682A /* AppleIIIInterface.h */; };
+		49EB4ED818C6702200AD682A /* AppleIIInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E1F18C6702200AD682A /* AppleIIInterface.h */; };
+		49EB4ED918C6702200AD682A /* RS232Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2118C6702200AD682A /* RS232Interface.h */; };
+		49EB4EDA18C6702200AD682A /* AudioPlayerInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2318C6702200AD682A /* AudioPlayerInterface.h */; };
+		49EB4EDB18C6702200AD682A /* ControlBusInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2418C6702200AD682A /* ControlBusInterface.h */; };
+		49EB4EDC18C6702200AD682A /* CPUInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2518C6702200AD682A /* CPUInterface.h */; };
+		49EB4EDD18C6702200AD682A /* MemoryInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4E2618C6702200AD682A /* MemoryInterface.cpp */; };
+		49EB4EDE18C6702200AD682A /* MemoryInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2718C6702200AD682A /* MemoryInterface.h */; };
+		49EB4EDF18C6702200AD682A /* PIAInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2818C6702200AD682A /* PIAInterface.h */; };
+		49EB4EE018C6702200AD682A /* AudioInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4E2A18C6702200AD682A /* AudioInterface.cpp */; };
+		49EB4EE118C6702200AD682A /* AudioInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2B18C6702200AD682A /* AudioInterface.h */; };
+		49EB4EE218C6702200AD682A /* CanvasInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2C18C6702200AD682A /* CanvasInterface.h */; };
+		49EB4EE318C6702200AD682A /* DeviceInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2D18C6702200AD682A /* DeviceInterface.h */; };
+		49EB4EE418C6702200AD682A /* EmulationInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2E18C6702200AD682A /* EmulationInterface.h */; };
+		49EB4EE518C6702200AD682A /* EthernetInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E2F18C6702200AD682A /* EthernetInterface.h */; };
+		49EB4EE618C6702200AD682A /* JoystickInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E3018C6702200AD682A /* JoystickInterface.h */; };
+		49EB4EE718C6702200AD682A /* MIDIInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E3118C6702200AD682A /* MIDIInterface.h */; };
+		49EB4EE818C6702200AD682A /* StorageInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E3218C6702200AD682A /* StorageInterface.h */; };
+		49EB4EE918C6702200AD682A /* USBInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E3318C6702200AD682A /* USBInterface.h */; };
+		49EB4EEA18C6702200AD682A /* VideoCaptureInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E3418C6702200AD682A /* VideoCaptureInterface.h */; };
+		49EB4EEB18C6702200AD682A /* IEEE1284Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E3618C6702200AD682A /* IEEE1284Interface.h */; };
+		49EB4EEC18C6702200AD682A /* IEEE1394Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E3718C6702200AD682A /* IEEE1394Interface.h */; };
+		49EB4EED18C6702200AD682A /* IEEE488Interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4E3818C6702200AD682A /* IEEE488Interface.h */; };
+		49EB4EF818C6709F00AD682A /* HIDJoystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4EEE18C6709F00AD682A /* HIDJoystick.cpp */; };
+		49EB4EF918C6709F00AD682A /* HIDJoystick.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4EEF18C6709F00AD682A /* HIDJoystick.h */; };
+		49EB4EFA18C6709F00AD682A /* OEMatrix3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4EF018C6709F00AD682A /* OEMatrix3.cpp */; };
+		49EB4EFB18C6709F00AD682A /* OEMatrix3.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4EF118C6709F00AD682A /* OEMatrix3.h */; };
+		49EB4EFC18C6709F00AD682A /* OEVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4EF218C6709F00AD682A /* OEVector.cpp */; };
+		49EB4EFD18C6709F00AD682A /* OEVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4EF318C6709F00AD682A /* OEVector.h */; };
+		49EB4EFE18C6709F00AD682A /* OpenGLCanvas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4EF418C6709F00AD682A /* OpenGLCanvas.cpp */; };
+		49EB4EFF18C6709F00AD682A /* OpenGLCanvas.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4EF518C6709F00AD682A /* OpenGLCanvas.h */; };
+		49EB4F0018C6709F00AD682A /* PAAudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4EF618C6709F00AD682A /* PAAudio.cpp */; };
+		49EB4F0118C6709F00AD682A /* PAAudio.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4EF718C6709F00AD682A /* PAAudio.h */; };
+		49EB4F0818C6737700AD682A /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49EB4F0618C6737700AD682A /* util.cpp */; };
+		49EB4F0918C6737700AD682A /* util.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EB4F0718C6737700AD682A /* util.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -353,7 +376,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				005486CA0FDC84E500DBCFA8 /* Sparkle.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -370,357 +392,364 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		00039CEB12B01D530025D374 /* EmulationUnmountPressed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationUnmountPressed.png; sourceTree = "<group>"; };
-		00039CF212B01D530025D374 /* EmulationShowPressed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationShowPressed.png; sourceTree = "<group>"; };
-		00039D2412B01EB40025D374 /* EmulationUnmountSelected.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationUnmountSelected.png; sourceTree = "<group>"; };
-		00039D2512B01EB40025D374 /* EmulationShowSelected.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationShowSelected.png; sourceTree = "<group>"; };
-		00039E0A12B0365A0025D374 /* EmulationUnmountRollover.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationUnmountRollover.png; sourceTree = "<group>"; };
-		00039E0B12B0365A0025D374 /* EmulationShowRollover.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationShowRollover.png; sourceTree = "<group>"; };
 		00039E7C12B03F660025D374 /* libemulation-hal.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libemulation-hal.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		00039EFE12B04E910025D374 /* libemulation.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libemulation.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		00039FD012B04F6C0025D374 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
-		00044CA112CE6FD400D26940 /* AppleDiskDrive525.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleDiskDrive525.h; sourceTree = "<group>"; };
-		00044CA212CE6FD400D26940 /* AppleDiskDrive525.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleDiskDrive525.cpp; sourceTree = "<group>"; };
-		0008FCD80FBA5D72005E876E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = macosx/Info.plist; sourceTree = "<group>"; };
-		0009068D141D2A0300F06D99 /* NSStringAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NSStringAdditions.mm; sourceTree = "<group>"; };
-		00092E5A156AA9D4007A9E04 /* VRAM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VRAM.cpp; sourceTree = "<group>"; };
-		00092E5B156AA9D4007A9E04 /* VRAM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VRAM.h; sourceTree = "<group>"; };
-		000A79190FBA49C500A0F12E /* OpenEmulator.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = OpenEmulator.icns; sourceTree = "<group>"; };
-		000E8D1813515C6E00DBFB2C /* StorageInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageInterface.h; sourceTree = "<group>"; };
-		000F66370FF8368F00C8AF23 /* DiskImage.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = DiskImage.icns; sourceTree = "<group>"; };
-		000F663A0FF8368F00C8AF23 /* Emulation.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Emulation.icns; sourceTree = "<group>"; };
-		000F66520FF8368F00C8AF23 /* OpenEmulator.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = OpenEmulator.icns; sourceTree = "<group>"; };
-		00139F83151195E600B0E108 /* AppleIIAddressDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIAddressDecoder.cpp; sourceTree = "<group>"; };
-		00139F85151195EE00B0E108 /* AppleIIAddressDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIAddressDecoder.h; sourceTree = "<group>"; };
-		00140DED152D281F00D4795D /* DIApple525DiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIApple525DiskStorage.h; sourceTree = "<group>"; };
-		00140DEF152D282400D4795D /* DIApple525DiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIApple525DiskStorage.cpp; sourceTree = "<group>"; };
-		00140DF5152D36F900D4795D /* DIFileBackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIFileBackingStore.cpp; sourceTree = "<group>"; };
-		00140DF7152D370300D4795D /* DIFileBackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIFileBackingStore.h; sourceTree = "<group>"; };
-		00140DF9152D371000D4795D /* DI2IMGBackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DI2IMGBackingStore.h; sourceTree = "<group>"; };
-		00140DFB152D371C00D4795D /* DI2IMGBackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DI2IMGBackingStore.cpp; sourceTree = "<group>"; };
-		00140E01152D375D00D4795D /* DIFDIDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIFDIDiskStorage.h; sourceTree = "<group>"; };
-		00140E03152D376400D4795D /* DIFDIDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIFDIDiskStorage.cpp; sourceTree = "<group>"; };
-		00140E09152D37ED00D4795D /* DIDC42BackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIDC42BackingStore.h; sourceTree = "<group>"; };
-		00140E0B152D37F400D4795D /* DIDC42BackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIDC42BackingStore.cpp; sourceTree = "<group>"; };
-		00140E11152D395900D4795D /* DIV2DDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIV2DDiskStorage.cpp; sourceTree = "<group>"; };
-		00140E13152D396500D4795D /* DIV2DDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIV2DDiskStorage.h; sourceTree = "<group>"; };
-		0014DF12148286A4006A7660 /* Application.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Application.h; sourceTree = "<group>"; };
-		0014DF13148286A5006A7660 /* Application.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Application.m; sourceTree = "<group>"; };
 		001750B013A50A9C0043E2ED /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
 		001750B113A50A9C0043E2ED /* COPYING */ = {isa = PBXFileReference; lastKnownFileType = text; path = COPYING; sourceTree = "<group>"; };
 		001750C013A50A9C0043E2ED /* INSTALL */ = {isa = PBXFileReference; lastKnownFileType = text; path = INSTALL; sourceTree = "<group>"; };
 		001750C113A50A9C0043E2ED /* NEWS */ = {isa = PBXFileReference; lastKnownFileType = text; path = NEWS; sourceTree = "<group>"; };
 		001750C213A50A9C0043E2ED /* README */ = {isa = PBXFileReference; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
 		001750C313A50A9C0043E2ED /* TODO */ = {isa = PBXFileReference; lastKnownFileType = text; path = TODO; sourceTree = "<group>"; };
-		0019177B1543D319009A301E /* DIDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIDiskStorage.h; sourceTree = "<group>"; };
-		0019177D1543D320009A301E /* DIDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIDiskStorage.cpp; sourceTree = "<group>"; };
-		0019177F1543D337009A301E /* DILogicalDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DILogicalDiskStorage.h; sourceTree = "<group>"; };
-		001917811543D346009A301E /* DILogicalDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DILogicalDiskStorage.cpp; sourceTree = "<group>"; };
-		001CC97E13D11EBC00B0DDA7 /* CPUInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUInterface.h; sourceTree = "<group>"; };
-		001D1F7A1479E7BD0014D496 /* JoystickInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JoystickInterface.h; sourceTree = "<group>"; };
-		001E09691556339400405DC0 /* AppleLanguageCard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleLanguageCard.cpp; sourceTree = "<group>"; };
-		001E096A1556339400405DC0 /* AppleLanguageCard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleLanguageCard.h; sourceTree = "<group>"; };
-		001F56F80FD1E8E500EA246A /* Sparkle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = Sparkle.framework; path = macosx/Sparkle.framework; sourceTree = "<group>"; };
-		0020AE701530A21F00E3DF80 /* DICommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DICommon.h; sourceTree = "<group>"; };
-		0020AE721530A22700E3DF80 /* DICommon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DICommon.cpp; sourceTree = "<group>"; };
-		0022236B142C557100B7451D /* ControlBusInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ControlBusInterface.h; sourceTree = "<group>"; };
-		00247F35139D85A900B165D1 /* OECommon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OECommon.cpp; sourceTree = "<group>"; };
-		00247F36139D85AA00B165D1 /* OECommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OECommon.h; sourceTree = "<group>"; };
-		002579FB1218A83400206E56 /* NSStringAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSStringAdditions.h; sourceTree = "<group>"; };
-		002740B613A08A4F00E13D65 /* VidexVideoterm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VidexVideoterm.cpp; sourceTree = "<group>"; };
-		002740B713A08A4F00E13D65 /* VidexVideoterm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VidexVideoterm.h; sourceTree = "<group>"; };
-		0027E67D153738CC0066A9BE /* DIVDIBlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIVDIBlockStorage.cpp; sourceTree = "<group>"; };
-		0027E67F153738D30066A9BE /* DIVDIBlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIVDIBlockStorage.h; sourceTree = "<group>"; };
-		0029EEDF14266B7700AD900E /* AddressMapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressMapper.cpp; sourceTree = "<group>"; };
-		0029EEE114266B8000AD900E /* AddressMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressMapper.h; sourceTree = "<group>"; };
 		002F57E515CDF4AC00C19659 /* libz.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libz.a; path = /opt/local/lib/libz.a; sourceTree = "<absolute>"; };
 		002F57E715CDF4B400C19659 /* libvorbis.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvorbis.a; path = /opt/local/lib/libvorbis.a; sourceTree = "<absolute>"; };
 		002F57E915CDF4B900C19659 /* libzip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libzip.a; path = /opt/local/lib/libzip.a; sourceTree = "<absolute>"; };
 		002F57EB15CDF4C000C19659 /* libsndfile.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsndfile.a; path = /opt/local/lib/libsndfile.a; sourceTree = "<absolute>"; };
 		002F57ED15CDF4C600C19659 /* libsamplerate.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsamplerate.a; path = /opt/local/lib/libsamplerate.a; sourceTree = "<absolute>"; };
 		002F57EF15CDF4CB00C19659 /* libportaudio.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libportaudio.a; path = /opt/local/lib/libportaudio.a; sourceTree = "<absolute>"; };
-		002F57F115CDF4D100C19659 /* libpng14.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpng14.a; path = /opt/local/lib/libpng14.a; sourceTree = "<absolute>"; };
 		002F57F315CDF66B00C19659 /* libogg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libogg.a; path = /opt/local/lib/libogg.a; sourceTree = "<absolute>"; };
-		002F57F515CDF6DF00C19659 /* libFLAC.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFLAC.a; path = /opt/local/lib/libFLAC.a; sourceTree = "<absolute>"; };
 		002F57F715CDF6F800C19659 /* libvorbisenc.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvorbisenc.a; path = /opt/local/lib/libvorbisenc.a; sourceTree = "<absolute>"; };
-		00365CEA1516955C00978DF6 /* AddressMux.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressMux.cpp; sourceTree = "<group>"; };
-		00365CEC1516956600978DF6 /* AddressMux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressMux.h; sourceTree = "<group>"; };
 		00365CF51516F3D800978DF6 /* libdiskimage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libdiskimage.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		00379130157B285E0020138F /* AppleGraphicsTabletInterfaceCard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleGraphicsTabletInterfaceCard.cpp; sourceTree = "<group>"; };
-		00379131157B285E0020138F /* AppleGraphicsTabletInterfaceCard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleGraphicsTabletInterfaceCard.h; sourceTree = "<group>"; };
-		00391CB112D3A320002C5ABD /* LibraryWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryWindowController.h; sourceTree = "<group>"; };
-		00391CB212D3A320002C5ABD /* LibraryWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibraryWindowController.m; sourceTree = "<group>"; };
-		00391D6012D3B570002C5ABD /* IconLibrary.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconLibrary.png; sourceTree = "<group>"; };
-		00391D6312D3B588002C5ABD /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/English.lproj/Library.xib; sourceTree = "<group>"; };
-		00391D9912D3B94F002C5ABD /* library */ = {isa = PBXFileReference; lastKnownFileType = folder; path = library; sourceTree = "<group>"; };
-		00391F6B12D3FFF3002C5ABD /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/English.lproj/TemplateChooserView.xib; sourceTree = "<group>"; };
 		003B158312EE26BA003FB8F6 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		003B165112EE275C003FB8F6 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		003B165712EE276E003FB8F6 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		003B167B12EE27ED003FB8F6 /* CoreAudioKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudioKit.framework; path = System/Library/Frameworks/CoreAudioKit.framework; sourceTree = SDKROOT; };
 		003B16C712EE2A61003FB8F6 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
-		003C0D5E15DB3BD200BCA5A4 /* AppleIIIInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIIIInterface.h; sourceTree = "<group>"; };
-		003E2597107075D900185260 /* images */ = {isa = PBXFileReference; lastKnownFileType = folder; path = images; sourceTree = "<group>"; };
-		0040284012B44878001C2F73 /* BackgroundView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackgroundView.h; sourceTree = "<group>"; };
-		0040284112B44878001C2F73 /* BackgroundView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundView.m; sourceTree = "<group>"; };
-		0042498E15B693DE0091ECAB /* AppleIIIMOS6502.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIMOS6502.cpp; sourceTree = "<group>"; };
-		0042498F15B693DE0091ECAB /* AppleIIIMOS6502.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIMOS6502.h; sourceTree = "<group>"; };
-		0042499215B694A60091ECAB /* AppleIIIMOS6502Opcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIMOS6502Opcodes.h; sourceTree = "<group>"; };
-		0042499415B696EA0091ECAB /* AppleIIIMOS6502Operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIMOS6502Operations.h; sourceTree = "<group>"; };
-		0042499615B8EA1C0091ECAB /* EmulationInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationInterface.h; sourceTree = "<group>"; };
-		0044FDD315D3784500F82C28 /* MM58167.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MM58167.cpp; sourceTree = "<group>"; };
-		0044FDD415D3784500F82C28 /* MM58167.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MM58167.h; sourceTree = "<group>"; };
-		004763D0139C94F30016277E /* LibraryTableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryTableView.h; sourceTree = "<group>"; };
-		004763D1139C94F30016277E /* LibraryTableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibraryTableView.m; sourceTree = "<group>"; };
-		004BD1BC1425AA8500768B80 /* W65C02S.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = W65C02S.cpp; sourceTree = "<group>"; };
-		004BD1BD1425AA8500768B80 /* W65C02S.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W65C02S.h; sourceTree = "<group>"; };
-		004BD1BE1425AA8500768B80 /* W65C02SOpcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W65C02SOpcodes.h; sourceTree = "<group>"; };
-		004BD1BF1425AA8500768B80 /* W65C02SOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W65C02SOperations.h; sourceTree = "<group>"; };
-		004E152915B9041A00FD22AB /* AppleIIISystemControl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIISystemControl.cpp; sourceTree = "<group>"; };
-		004E152C15B9042100FD22AB /* AppleIIISystemControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIISystemControl.h; sourceTree = "<group>"; };
-		005316C21596D268007F3C86 /* AppleSilentypeInterfaceCard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleSilentypeInterfaceCard.cpp; sourceTree = "<group>"; };
-		005316C41596D2BF007F3C86 /* Proxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Proxy.h; sourceTree = "<group>"; };
-		005316C61596D2C8007F3C86 /* Proxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Proxy.cpp; sourceTree = "<group>"; };
-		00536BC4153DD3F5005A5336 /* DIVMDKBlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIVMDKBlockStorage.h; sourceTree = "<group>"; };
-		00536BC5153DD400005A5336 /* DIVMDKBlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIVMDKBlockStorage.cpp; sourceTree = "<group>"; };
-		0054868F0FDC817900DBCFA8 /* Emulation.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Emulation.icns; sourceTree = "<group>"; };
 		0054E4A01131BE7A006D32D9 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		0054E4A61131BE8A006D32D9 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		0054E6301131BEE7006D32D9 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		0054E66B1131BF58006D32D9 /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
-		005928540FFC94E200F24A57 /* templates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = templates; sourceTree = "<group>"; };
 		0062F75315E950BE00481ECB /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		0062F75C15E950D800481ECB /* cmake */ = {isa = PBXFileReference; lastKnownFileType = folder; path = cmake; sourceTree = "<group>"; };
-		00679D07100817F700B38748 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/English.lproj/TemplateChooser.xib; sourceTree = "<group>"; };
-		006A4C5B134ED2F30033BE4D /* IEEE488Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IEEE488Interface.h; sourceTree = "<group>"; };
-		006EEE8F0FCA781C003D2C8D /* DiskImage.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = DiskImage.icns; sourceTree = "<group>"; };
-		0071E3B810803F7300F2D54F /* TemplateChooserItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemplateChooserItem.h; sourceTree = "<group>"; };
-		0071E3B910803F7300F2D54F /* TemplateChooserItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TemplateChooserItem.mm; sourceTree = "<group>"; };
-		00722D3B1470E31400FE7007 /* Apple1Terminal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Apple1Terminal.cpp; sourceTree = "<group>"; };
-		0073DD8D136FCA1C00087303 /* CanvasToolbarView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasToolbarView.h; sourceTree = "<group>"; };
-		0073DD8E136FCA1C00087303 /* CanvasToolbarView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CanvasToolbarView.m; sourceTree = "<group>"; };
-		0073DDBE136FCCC900087303 /* ToolbarBackground.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ToolbarBackground.png; sourceTree = "<group>"; };
-		0076FD6412A1ED8C00A3FEC7 /* AudioPause.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioPause.png; sourceTree = "<group>"; };
-		0077271D15D8137F008AB5A2 /* AppleIIIBeeper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIIIBeeper.h; sourceTree = "<group>"; };
-		0077271F15D81387008AB5A2 /* AppleIIIBeeper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIBeeper.cpp; sourceTree = "<group>"; };
-		0078F654127348ED0042577E /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/English.lproj/AudioControls.xib; sourceTree = "<group>"; };
-		007DEFAA153FB0CB00A9CC01 /* DIBackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIBackingStore.h; sourceTree = "<group>"; };
-		007DEFAC153FB15C00A9CC01 /* DIRAMBackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIRAMBackingStore.h; sourceTree = "<group>"; };
-		007DEFAE153FB16800A9CC01 /* DIRAMBackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIRAMBackingStore.cpp; sourceTree = "<group>"; };
-		007DEFB0153FB17500A9CC01 /* DIBackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIBackingStore.cpp; sourceTree = "<group>"; };
-		007DEFB2153FB5E800A9CC01 /* DIBlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIBlockStorage.cpp; sourceTree = "<group>"; };
-		007DEFB4153FB5EF00A9CC01 /* DIBlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIBlockStorage.h; sourceTree = "<group>"; };
-		007DEFB81540607C00A9CC01 /* DIRAWBlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIRAWBlockStorage.h; sourceTree = "<group>"; };
-		007DEFBA1540608200A9CC01 /* DIRAWBlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIRAWBlockStorage.cpp; sourceTree = "<group>"; };
-		007EF9C61570329D0073061E /* IconRevert.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconRevert.png; sourceTree = "<group>"; };
-		007F08CE1459344600C3308D /* sparkle_dsa_pub.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = sparkle_dsa_pub.pem; path = macosx/sparkle_dsa_pub.pem; sourceTree = "<group>"; };
-		007F6C3415CD052D0004D4C4 /* AppleIIIAddressDecoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIIIAddressDecoder.h; sourceTree = "<group>"; };
-		007F6C3615CD05370004D4C4 /* AppleIIIAddressDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIAddressDecoder.cpp; sourceTree = "<group>"; };
-		007F6C3815CD064C0004D4C4 /* MOS6551.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MOS6551.h; sourceTree = "<group>"; };
-		007F6C3915CD06520004D4C4 /* MOS6551.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOS6551.cpp; sourceTree = "<group>"; };
-		007F6C3B15CD068C0004D4C4 /* AppleIIIGamePort.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIIIGamePort.h; sourceTree = "<group>"; };
-		007F6C3C15CD06930004D4C4 /* AppleIIIGamePort.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIGamePort.cpp; sourceTree = "<group>"; };
-		00811DFD12D251E9009AD2F0 /* AppleDiskIIInterfaceCard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleDiskIIInterfaceCard.h; sourceTree = "<group>"; };
-		00811DFE12D251E9009AD2F0 /* AppleDiskIIInterfaceCard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleDiskIIInterfaceCard.cpp; sourceTree = "<group>"; };
-		00811F1012D2738B009AD2F0 /* AppleGraphicsTablet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleGraphicsTablet.h; sourceTree = "<group>"; };
-		00811F1112D2738B009AD2F0 /* AppleGraphicsTablet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleGraphicsTablet.cpp; sourceTree = "<group>"; };
-		008363051326C15300CB9A21 /* OpenGLCanvas.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OpenGLCanvas.cpp; sourceTree = "<group>"; };
-		008363061326C15300CB9A21 /* OpenGLCanvas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenGLCanvas.h; sourceTree = "<group>"; };
-		008363071326C15300CB9A21 /* OEVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEVector.cpp; sourceTree = "<group>"; };
-		008363081326C15300CB9A21 /* OEVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEVector.h; sourceTree = "<group>"; };
-		008363091326C15300CB9A21 /* PAAudio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PAAudio.cpp; sourceTree = "<group>"; };
-		0083630A1326C15300CB9A21 /* PAAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PAAudio.h; sourceTree = "<group>"; };
-		00839E44159705FC00BD4538 /* ATAController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ATAController.cpp; sourceTree = "<group>"; };
-		00839E45159705FC00BD4538 /* ATAController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATAController.h; sourceTree = "<group>"; };
-		0084D43514FC4FF80031A8A5 /* Audio1Bit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Audio1Bit.cpp; sourceTree = "<group>"; };
-		0084D43714FC50060031A8A5 /* Audio1Bit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Audio1Bit.h; sourceTree = "<group>"; };
-		008696AB15C8FC89000737EE /* AppleIIIDiskIO.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIIIDiskIO.h; sourceTree = "<group>"; };
-		008696AC15C8FC93000737EE /* AppleIIIDiskIO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIDiskIO.cpp; sourceTree = "<group>"; };
-		008696AE15CB903E000737EE /* AppleIISystemControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIISystemControl.h; sourceTree = "<group>"; };
-		008696AF15CB9047000737EE /* AppleIISystemControl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIISystemControl.cpp; sourceTree = "<group>"; };
 		008CA97D147803E500B9F5D0 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		008CB9A415E7B08300027B7B /* AppleIIIRTC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIIIRTC.h; sourceTree = "<group>"; };
-		008CB9A615E7B08A00027B7B /* AppleIIIRTC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIRTC.cpp; sourceTree = "<group>"; };
-		008CB9A815E7B0A900027B7B /* AppleIIIVideo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIIIVideo.h; sourceTree = "<group>"; };
-		008CB9A915E7B0AE00027B7B /* AppleIIIVideo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIVideo.cpp; sourceTree = "<group>"; };
-		0090853E1395D23D00B7D75F /* LibraryItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryItem.h; sourceTree = "<group>"; };
-		0090853F1395D23D00B7D75F /* LibraryItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LibraryItem.mm; sourceTree = "<group>"; };
-		00936E8515170428006B0EAC /* AudioPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioPlayer.h; sourceTree = "<group>"; };
-		00936E8715170435006B0EAC /* AudioPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioPlayer.cpp; sourceTree = "<group>"; };
-		00936E8915177B60006B0EAC /* AudioPlayerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioPlayerInterface.h; sourceTree = "<group>"; };
-		00954E761277B79E00C17203 /* EmulationOutlineCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationOutlineCell.h; sourceTree = "<group>"; };
-		00954E771277B79E00C17203 /* EmulationOutlineCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EmulationOutlineCell.m; sourceTree = "<group>"; };
-		00954E971277BB8E00C17203 /* EmulationWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationWindowController.h; sourceTree = "<group>"; };
-		00954E981277BB8E00C17203 /* EmulationWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EmulationWindowController.m; sourceTree = "<group>"; };
-		00954EA51277BC1200C17203 /* AudioControlsWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioControlsWindowController.h; sourceTree = "<group>"; };
-		00954EA61277BC1200C17203 /* AudioControlsWindowController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioControlsWindowController.mm; sourceTree = "<group>"; };
-		00A06AE21533055600A494A7 /* DIATABlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIATABlockStorage.cpp; sourceTree = "<group>"; };
-		00A06AE41533055D00A494A7 /* DIATABlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIATABlockStorage.h; sourceTree = "<group>"; };
-		00A06AE61533EE2700A494A7 /* DIApple35DiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIApple35DiskStorage.h; sourceTree = "<group>"; };
-		00A06AE81533EE3100A494A7 /* DIApple35DiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIApple35DiskStorage.cpp; sourceTree = "<group>"; };
-		00A0B7B81068949D007930A5 /* Document.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Document.h; sourceTree = "<group>"; };
-		00A0B8031069761A007930A5 /* Document.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Document.mm; sourceTree = "<group>"; };
-		00A12994147A8E7500DF323F /* HIDJoystick.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HIDJoystick.cpp; sourceTree = "<group>"; };
-		00A12996147A8E7E00DF323F /* HIDJoystick.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HIDJoystick.h; sourceTree = "<group>"; };
-		00A72B6912879F530083C6A7 /* CanvasWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasWindowController.h; sourceTree = "<group>"; };
-		00A72B6A12879F530083C6A7 /* CanvasWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CanvasWindowController.m; sourceTree = "<group>"; };
-		00A72B6D12879F650083C6A7 /* CanvasView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasView.h; sourceTree = "<group>"; };
-		00A72B6E12879F650083C6A7 /* CanvasView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CanvasView.mm; sourceTree = "<group>"; };
-		00A72B7112879F800083C6A7 /* CanvasWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasWindow.h; sourceTree = "<group>"; };
-		00A72B7212879F800083C6A7 /* CanvasWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CanvasWindow.m; sourceTree = "<group>"; };
-		00A72B941287A0F10083C6A7 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/English.lproj/Canvas.xib; sourceTree = "<group>"; };
-		00A90FB2150D3A0000BB2999 /* MemoryInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryInterface.cpp; sourceTree = "<group>"; };
-		00A90FB4150D3A0E00BB2999 /* AudioInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioInterface.cpp; sourceTree = "<group>"; };
-		00A9739E12E512F80084724F /* OEEmulation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEEmulation.cpp; sourceTree = "<group>"; };
-		00A9739F12E512F80084724F /* OEEmulation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEEmulation.h; sourceTree = "<group>"; };
-		00A973A012E512F80084724F /* OEComponent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEComponent.cpp; sourceTree = "<group>"; };
-		00A973A112E512F80084724F /* OEComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEComponent.h; sourceTree = "<group>"; };
-		00A973A212E512F80084724F /* OEComponentFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEComponentFactory.cpp; sourceTree = "<group>"; };
-		00A973A312E512F80084724F /* OEComponentFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEComponentFactory.h; sourceTree = "<group>"; };
-		00A973A412E512F80084724F /* OEDocument.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEDocument.cpp; sourceTree = "<group>"; };
-		00A973A512E512F80084724F /* OEDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDocument.h; sourceTree = "<group>"; };
-		00A973A612E512F80084724F /* OEImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEImage.cpp; sourceTree = "<group>"; };
-		00A973A712E512F80084724F /* OEImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEImage.h; sourceTree = "<group>"; };
-		00A973A812E512F80084724F /* OEPackage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEPackage.cpp; sourceTree = "<group>"; };
-		00A973A912E512F80084724F /* OEPackage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEPackage.h; sourceTree = "<group>"; };
-		00AB963B157F9E8200EDACD5 /* AppleSilentypeInterfaceCard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleSilentypeInterfaceCard.h; sourceTree = "<group>"; };
-		00AB96A5158053BF00EDACD5 /* AppleIIDisableC800.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIDisableC800.cpp; sourceTree = "<group>"; };
-		00AB96A6158053C000EDACD5 /* AppleIIDisableC800.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIDisableC800.h; sourceTree = "<group>"; };
-		00AD7025151AC19100424637 /* OESound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OESound.h; sourceTree = "<group>"; };
-		00AD7027151AC41E00424637 /* OESound.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OESound.cpp; sourceTree = "<group>"; };
-		00AD746811A2F10E00BAC29C /* DocumentController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DocumentController.mm; sourceTree = "<group>"; };
-		00B019B213501507001E01BB /* OEDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDevice.h; sourceTree = "<group>"; };
-		00B019B313501507001E01BB /* OEDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEDevice.cpp; sourceTree = "<group>"; };
-		00B5709C10863C2A00CDE4A7 /* TemplateChooserWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemplateChooserWindowController.h; sourceTree = "<group>"; };
-		00B5709D10863C2A00CDE4A7 /* TemplateChooserWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TemplateChooserWindowController.m; sourceTree = "<group>"; };
-		00B5CB92136F0B6C007A7BED /* AppleSilentype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleSilentype.cpp; sourceTree = "<group>"; };
-		00B5CB93136F0B6C007A7BED /* AppleSilentype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleSilentype.h; sourceTree = "<group>"; };
-		00B6A2DD15B1FC97005E7A5C /* DIDDLDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DIDDLDiskStorage.cpp; sourceTree = "<group>"; };
-		00B6A2DE15B1FC97005E7A5C /* DIDDLDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIDDLDiskStorage.h; sourceTree = "<group>"; };
-		00B7C644147B4B2B00BB7E6B /* JoystickMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JoystickMapper.h; sourceTree = "<group>"; };
-		00B7C645147B4B4100BB7E6B /* JoystickMapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JoystickMapper.cpp; sourceTree = "<group>"; };
-		00B7C647147B5B2300BB7E6B /* AppleIIGamePort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIGamePort.h; sourceTree = "<group>"; };
-		00B7C649147B5B2B00BB7E6B /* AppleIIGamePort.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIGamePort.cpp; sourceTree = "<group>"; };
-		00B8864612A3923D0052B7A4 /* edl-1.0.dtd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "edl-1.0.dtd"; sourceTree = "<group>"; };
-		00B8881312A393990052B7A4 /* Apple1ACI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Apple1ACI.cpp; sourceTree = "<group>"; };
-		00B8881412A393990052B7A4 /* Apple1ACI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Apple1ACI.h; sourceTree = "<group>"; };
-		00B8881812A393990052B7A4 /* Apple1Terminal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Apple1Terminal.h; sourceTree = "<group>"; };
-		00B8881912A393990052B7A4 /* AppleIIAudioIn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIAudioIn.cpp; sourceTree = "<group>"; };
-		00B8881A12A393990052B7A4 /* AppleIIAudioIn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIAudioIn.h; sourceTree = "<group>"; };
-		00B8881B12A393990052B7A4 /* AppleIIAudioOut.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIAudioOut.cpp; sourceTree = "<group>"; };
-		00B8881C12A393990052B7A4 /* AppleIIAudioOut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIAudioOut.h; sourceTree = "<group>"; };
-		00B8881F12A393990052B7A4 /* AppleIIFloatingBus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIFloatingBus.cpp; sourceTree = "<group>"; };
-		00B8882012A393990052B7A4 /* AppleIIFloatingBus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIFloatingBus.h; sourceTree = "<group>"; };
-		00B8882312A393990052B7A4 /* AppleIIKeyboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIKeyboard.cpp; sourceTree = "<group>"; };
-		00B8882412A393990052B7A4 /* AppleIIKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIKeyboard.h; sourceTree = "<group>"; };
-		00B8882912A393990052B7A4 /* AppleIISlotController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIISlotController.cpp; sourceTree = "<group>"; };
-		00B8882A12A393990052B7A4 /* AppleIISlotController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIISlotController.h; sourceTree = "<group>"; };
-		00B8882B12A393990052B7A4 /* AppleIIVideo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIVideo.cpp; sourceTree = "<group>"; };
-		00B8882C12A393990052B7A4 /* AppleIIVideo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIVideo.h; sourceTree = "<group>"; };
-		00B8882E12A393990052B7A4 /* AddressDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressDecoder.cpp; sourceTree = "<group>"; };
-		00B8882F12A393990052B7A4 /* AddressDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressDecoder.h; sourceTree = "<group>"; };
-		00B8883012A393990052B7A4 /* AddressOffset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressOffset.cpp; sourceTree = "<group>"; };
-		00B8883112A393990052B7A4 /* AddressOffset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressOffset.h; sourceTree = "<group>"; };
-		00B8883212A393990052B7A4 /* AudioCodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioCodec.cpp; sourceTree = "<group>"; };
-		00B8883612A393990052B7A4 /* Monitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Monitor.cpp; sourceTree = "<group>"; };
-		00B8883712A393990052B7A4 /* Monitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Monitor.h; sourceTree = "<group>"; };
-		00B8883812A393990052B7A4 /* ControlBus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ControlBus.cpp; sourceTree = "<group>"; };
-		00B8883912A393990052B7A4 /* ControlBus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ControlBus.h; sourceTree = "<group>"; };
-		00B8883A12A393990052B7A4 /* FloatingBus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatingBus.cpp; sourceTree = "<group>"; };
-		00B8883B12A393990052B7A4 /* FloatingBus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FloatingBus.h; sourceTree = "<group>"; };
-		00B8883C12A393990052B7A4 /* RAM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RAM.cpp; sourceTree = "<group>"; };
-		00B8883D12A393990052B7A4 /* RAM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RAM.h; sourceTree = "<group>"; };
-		00B8883E12A393990052B7A4 /* ROM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ROM.cpp; sourceTree = "<group>"; };
-		00B8883F12A393990052B7A4 /* ROM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ROM.h; sourceTree = "<group>"; };
-		00B8884312A393990052B7A4 /* MOS6502.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOS6502.cpp; sourceTree = "<group>"; };
-		00B8884412A393990052B7A4 /* MOS6502.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6502.h; sourceTree = "<group>"; };
-		00B8884512A393990052B7A4 /* MOS6502IllegalOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6502IllegalOperations.h; sourceTree = "<group>"; };
-		00B8884612A393990052B7A4 /* MOS6502Opcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6502Opcodes.h; sourceTree = "<group>"; };
-		00B8884712A393990052B7A4 /* MOS6502Operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6502Operations.h; sourceTree = "<group>"; };
-		00B8884C12A393990052B7A4 /* MOS6530.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOS6530.cpp; sourceTree = "<group>"; };
-		00B8884D12A393990052B7A4 /* MOS6530.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6530.h; sourceTree = "<group>"; };
-		00B8884E12A393990052B7A4 /* MOSKIM1IO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOSKIM1IO.cpp; sourceTree = "<group>"; };
-		00B8884F12A393990052B7A4 /* MOSKIM1IO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOSKIM1IO.h; sourceTree = "<group>"; };
-		00B8885012A393990052B7A4 /* MOSKIM1PLL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOSKIM1PLL.cpp; sourceTree = "<group>"; };
-		00B8885112A393990052B7A4 /* MOSKIM1PLL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOSKIM1PLL.h; sourceTree = "<group>"; };
-		00B8885312A393990052B7A4 /* MC6821.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MC6821.cpp; sourceTree = "<group>"; };
-		00B8885412A393990052B7A4 /* MC6821.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MC6821.h; sourceTree = "<group>"; };
-		00B8885512A393990052B7A4 /* MC6845.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MC6845.cpp; sourceTree = "<group>"; };
-		00B8885612A393990052B7A4 /* MC6845.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MC6845.h; sourceTree = "<group>"; };
-		00B8886B12A393990052B7A4 /* AppleIIInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppleIIInterface.h; path = libemulation/Interface/Apple/AppleIIInterface.h; sourceTree = SOURCE_ROOT; };
-		00B8886D12A393990052B7A4 /* RS232Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RS232Interface.h; path = libemulation/Interface/EIA/RS232Interface.h; sourceTree = SOURCE_ROOT; };
-		00B8887F12A393990052B7A4 /* IEEE1284Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IEEE1284Interface.h; path = libemulation/Interface/IEEE/IEEE1284Interface.h; sourceTree = SOURCE_ROOT; };
-		00B974AD10701DCD00BD1402 /* sounds */ = {isa = PBXFileReference; lastKnownFileType = folder; path = sounds; sourceTree = "<group>"; };
-		00BB34B212C5C5AE007332B5 /* EmulationItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationItem.h; sourceTree = "<group>"; };
-		00BB34B312C5C5AE007332B5 /* EmulationItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EmulationItem.mm; sourceTree = "<group>"; };
-		00BDB1F513863188004DF2AF /* CanvasPrintView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasPrintView.h; sourceTree = "<group>"; };
-		00BDB1F613863188004DF2AF /* CanvasPrintView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CanvasPrintView.m; sourceTree = "<group>"; };
 		00BE6E4415E2DA3C004364E4 /* doc */ = {isa = PBXFileReference; lastKnownFileType = folder; path = doc; sourceTree = SOURCE_ROOT; };
-		00C6C08810602151004D084B /* roms */ = {isa = PBXFileReference; lastKnownFileType = folder; path = roms; sourceTree = "<group>"; };
-		00CAD7D812A04C22002B92E5 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/English.lproj/Emulation.xib; sourceTree = "<group>"; };
-		00CF206F15B0D8C600DA8E08 /* util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = util.cpp; path = libutil/util.cpp; sourceTree = "<group>"; };
-		00CF207015B0D8C600DA8E08 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = util.h; path = libutil/util.h; sourceTree = "<group>"; };
 		00CF207615B0D8D300DA8E08 /* libutil.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libutil.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		00D225FA1350F9A100FC69B9 /* AudioInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioInterface.h; sourceTree = "<group>"; };
-		00D225FB1350F9A100FC69B9 /* CanvasInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasInterface.h; sourceTree = "<group>"; };
-		00D225FD1350F9A100FC69B9 /* DeviceInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceInterface.h; sourceTree = "<group>"; };
-		00D225FF1350F9A100FC69B9 /* EthernetInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EthernetInterface.h; sourceTree = "<group>"; };
-		00D226001350F9A100FC69B9 /* MIDIInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MIDIInterface.h; sourceTree = "<group>"; };
-		00D226031350F9A100FC69B9 /* USBInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = USBInterface.h; sourceTree = "<group>"; };
-		00D226041350F9A100FC69B9 /* VideoCaptureInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoCaptureInterface.h; sourceTree = "<group>"; };
-		00D226541350FF8B00FC69B9 /* OEMatrix3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEMatrix3.h; sourceTree = "<group>"; };
-		00D226551350FF8B00FC69B9 /* OEMatrix3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEMatrix3.cpp; sourceTree = "<group>"; };
-		00D6FB7B15B3CCD00063312F /* ddl-1.0.dtd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = "ddl-1.0.dtd"; path = "libemulation/ddl-1.0.dtd"; sourceTree = SOURCE_ROOT; };
-		00D73D9C136CC9B300BD5465 /* IEEE1394Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IEEE1394Interface.h; sourceTree = "<group>"; };
-		00D75C671399FFD7004AA153 /* LibraryTableCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryTableCell.h; sourceTree = "<group>"; };
-		00D75C681399FFD9004AA153 /* LibraryTableCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibraryTableCell.m; sourceTree = "<group>"; };
-		00D7E40E158D1E4B00EBF8FA /* AddressMasker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressMasker.cpp; sourceTree = "<group>"; };
-		00D7E40F158D1E4B00EBF8FA /* AddressMasker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressMasker.h; sourceTree = "<group>"; };
-		00D844BE0FFF0505005802F0 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/English.lproj/MainMenu.xib; sourceTree = "<group>"; };
-		00D844C40FFF0505005802F0 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = macosx/English.lproj/Preferences.xib; sourceTree = "<group>"; };
-		00D845670FFF0FD2005802F0 /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
-		00D845730FFF0FD2005802F0 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		00D845760FFF0FD2005802F0 /* OpenEmulator_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenEmulator_Prefix.pch; sourceTree = "<group>"; };
-		00D845790FFF0FD2005802F0 /* PreferencesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreferencesWindowController.h; sourceTree = "<group>"; };
-		00D8457A0FFF0FD2005802F0 /* PreferencesWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PreferencesWindowController.m; sourceTree = "<group>"; };
-		00D96F4A15E010A30066EB0C /* AppleIIIKeyboard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleIIIKeyboard.h; sourceTree = "<group>"; };
-		00D96F4B15E010AD0066EB0C /* AppleIIIKeyboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIKeyboard.cpp; sourceTree = "<group>"; };
-		00DC0E78145DFECD00FF51BD /* MemoryInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryInterface.h; sourceTree = "<group>"; };
-		00E442911278726B00713A05 /* IconDevices.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconDevices.png; sourceTree = "<group>"; };
-		00E442931278727600713A05 /* EmulationShow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationShow.png; sourceTree = "<group>"; };
-		00E473411475695500F367B7 /* diskimage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = diskimage.h; sourceTree = "<group>"; };
-		00EA1F0315976F0200079A54 /* ATADevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ATADevice.cpp; sourceTree = "<group>"; };
-		00EA1F0415976F0200079A54 /* ATADevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATADevice.h; sourceTree = "<group>"; };
-		00EA1F08159799C400079A54 /* RDCFFA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RDCFFA.cpp; sourceTree = "<group>"; };
-		00EA1F09159799C400079A54 /* RDCFFA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RDCFFA.h; sourceTree = "<group>"; };
-		00ED379712779AD000BEF6BD /* AudioMax.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioMax.png; sourceTree = "<group>"; };
-		00ED379812779AD000BEF6BD /* AudioMin.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioMin.png; sourceTree = "<group>"; };
-		00ED379912779AD000BEF6BD /* AudioPlay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioPlay.png; sourceTree = "<group>"; };
-		00ED379A12779AD000BEF6BD /* AudioRecord.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioRecord.png; sourceTree = "<group>"; };
-		00ED379B12779AD000BEF6BD /* AudioStop.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioStop.png; sourceTree = "<group>"; };
-		00ED37A812779DD800BEF6BD /* IconAudio.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconAudio.png; sourceTree = "<group>"; };
-		00ED37A912779DD800BEF6BD /* IconColdRestart.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconColdRestart.png; sourceTree = "<group>"; };
-		00ED37AA12779DD800BEF6BD /* IconDebuggerBreak.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconDebuggerBreak.png; sourceTree = "<group>"; };
-		00ED37AB12779DD800BEF6BD /* IconGeneral.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconGeneral.png; sourceTree = "<group>"; };
-		00ED37AC12779DD800BEF6BD /* IconInspector.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconInspector.png; sourceTree = "<group>"; };
-		00ED37AD12779DD800BEF6BD /* IconPowerDown.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconPowerDown.png; sourceTree = "<group>"; };
-		00ED37AE12779DD800BEF6BD /* IconSleep.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconSleep.png; sourceTree = "<group>"; };
-		00ED37AF12779DD800BEF6BD /* IconVideo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconVideo.png; sourceTree = "<group>"; };
-		00ED37B012779DD800BEF6BD /* IconWakeUp.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconWakeUp.png; sourceTree = "<group>"; };
-		00ED37B112779DD800BEF6BD /* IconWarmRestart.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconWarmRestart.png; sourceTree = "<group>"; };
-		00F01B4612A0D6EC000527CA /* EmulationUnmount.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationUnmount.png; sourceTree = "<group>"; };
-		00F21CE512C7C7EE00A809EF /* VerticallyCenteredTextFieldCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VerticallyCenteredTextFieldCell.h; sourceTree = "<group>"; };
-		00F21CE612C7C7EE00A809EF /* VerticallyCenteredTextFieldCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VerticallyCenteredTextFieldCell.m; sourceTree = "<group>"; };
-		00F2796E15B671E600E58F4F /* MOS6522.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOS6522.cpp; sourceTree = "<group>"; };
-		00F2797115B671EE00E58F4F /* MOS6522.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6522.h; sourceTree = "<group>"; };
-		00F397E3141655DA00C53A3E /* Apple1IO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Apple1IO.cpp; sourceTree = "<group>"; };
-		00F397E5141655EB00C53A3E /* Apple1IO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Apple1IO.h; sourceTree = "<group>"; };
 		00F4D0BE12E2E42F00B7F5E6 /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
-		00FBD2DD1419A03A00BA8CEE /* AudioCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioCodec.h; sourceTree = "<group>"; };
-		00FE0C041095353B00B92AB7 /* TemplateChooserViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemplateChooserViewController.h; sourceTree = "<group>"; };
-		00FE0C051095353B00B92AB7 /* TemplateChooserViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TemplateChooserViewController.m; sourceTree = "<group>"; };
-		00FE381912CA6790002B47B1 /* EmulationOutlineView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationOutlineView.h; sourceTree = "<group>"; };
-		00FE381A12CA6790002B47B1 /* EmulationOutlineView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EmulationOutlineView.m; sourceTree = "<group>"; };
+		496AF1D718C677B600B35159 /* images */ = {isa = PBXFileReference; lastKnownFileType = folder; name = images; path = res/images; sourceTree = "<group>"; };
+		496AF1D818C677B600B35159 /* library */ = {isa = PBXFileReference; lastKnownFileType = folder; name = library; path = res/library; sourceTree = "<group>"; };
+		496AF1D918C677B600B35159 /* sounds */ = {isa = PBXFileReference; lastKnownFileType = folder; name = sounds; path = res/sounds; sourceTree = "<group>"; };
+		496AF1DA18C677B600B35159 /* templates */ = {isa = PBXFileReference; lastKnownFileType = folder; name = templates; path = res/templates; sourceTree = "<group>"; };
+		496AF1DF18C746F300B35159 /* roms */ = {isa = PBXFileReference; lastKnownFileType = folder; name = roms; path = res/roms; sourceTree = "<group>"; };
+		49EB4C4218C63B1800AD682A /* libFLAC.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libFLAC.dylib; path = ../../../../opt/local/lib/libFLAC.dylib; sourceTree = "<group>"; };
+		49EB4C4A18C63BE500AD682A /* Application.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Application.h; sourceTree = "<group>"; };
+		49EB4C4B18C63BE500AD682A /* Application.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Application.m; sourceTree = "<group>"; };
+		49EB4C4C18C63BE500AD682A /* AudioControlsWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioControlsWindowController.h; sourceTree = "<group>"; };
+		49EB4C4D18C63BE500AD682A /* AudioControlsWindowController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioControlsWindowController.mm; sourceTree = "<group>"; };
+		49EB4C4E18C63BE500AD682A /* BackgroundView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackgroundView.h; sourceTree = "<group>"; };
+		49EB4C4F18C63BE500AD682A /* BackgroundView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundView.m; sourceTree = "<group>"; };
+		49EB4C5018C63BE500AD682A /* CanvasPrintView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasPrintView.h; sourceTree = "<group>"; };
+		49EB4C5118C63BE500AD682A /* CanvasPrintView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CanvasPrintView.m; sourceTree = "<group>"; };
+		49EB4C5218C63BE500AD682A /* CanvasToolbarView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasToolbarView.h; sourceTree = "<group>"; };
+		49EB4C5318C63BE500AD682A /* CanvasToolbarView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CanvasToolbarView.m; sourceTree = "<group>"; };
+		49EB4C5418C63BE500AD682A /* CanvasView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasView.h; sourceTree = "<group>"; };
+		49EB4C5518C63BE500AD682A /* CanvasView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CanvasView.mm; sourceTree = "<group>"; };
+		49EB4C5618C63BE500AD682A /* CanvasWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasWindow.h; sourceTree = "<group>"; };
+		49EB4C5718C63BE500AD682A /* CanvasWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CanvasWindow.m; sourceTree = "<group>"; };
+		49EB4C5818C63BE500AD682A /* CanvasWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasWindowController.h; sourceTree = "<group>"; };
+		49EB4C5918C63BE500AD682A /* CanvasWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CanvasWindowController.m; sourceTree = "<group>"; };
+		49EB4C5A18C63BE500AD682A /* Document.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Document.h; sourceTree = "<group>"; };
+		49EB4C5B18C63BE500AD682A /* Document.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Document.mm; sourceTree = "<group>"; };
+		49EB4C5C18C63BE500AD682A /* DocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentController.h; sourceTree = "<group>"; };
+		49EB4C5D18C63BE500AD682A /* DocumentController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DocumentController.mm; sourceTree = "<group>"; };
+		49EB4C5E18C63BE500AD682A /* EmulationItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationItem.h; sourceTree = "<group>"; };
+		49EB4C5F18C63BE500AD682A /* EmulationItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EmulationItem.mm; sourceTree = "<group>"; };
+		49EB4C6018C63BE500AD682A /* EmulationOutlineCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationOutlineCell.h; sourceTree = "<group>"; };
+		49EB4C6118C63BE500AD682A /* EmulationOutlineCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EmulationOutlineCell.m; sourceTree = "<group>"; };
+		49EB4C6218C63BE500AD682A /* EmulationOutlineView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationOutlineView.h; sourceTree = "<group>"; };
+		49EB4C6318C63BE500AD682A /* EmulationOutlineView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EmulationOutlineView.m; sourceTree = "<group>"; };
+		49EB4C6418C63BE500AD682A /* EmulationWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationWindowController.h; sourceTree = "<group>"; };
+		49EB4C6518C63BE500AD682A /* EmulationWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EmulationWindowController.m; sourceTree = "<group>"; };
+		49EB4C6718C63BE500AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/AudioControls.xib; sourceTree = "<group>"; };
+		49EB4C6918C63BE500AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/Canvas.xib; sourceTree = "<group>"; };
+		49EB4C6B18C63BE500AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/Emulation.xib; sourceTree = "<group>"; };
+		49EB4C6D18C63BE500AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/Library.xib; sourceTree = "<group>"; };
+		49EB4C6F18C63BE500AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		49EB4C7118C63BE500AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/Preferences.xib; sourceTree = "<group>"; };
+		49EB4C7318C63BE500AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/TemplateChooser.xib; sourceTree = "<group>"; };
+		49EB4C7518C63BE500AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/TemplateChooserView.xib; sourceTree = "<group>"; };
+		49EB4C7718C63BE500AD682A /* AudioMax.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioMax.png; sourceTree = "<group>"; };
+		49EB4C7818C63BE500AD682A /* AudioMin.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioMin.png; sourceTree = "<group>"; };
+		49EB4C7918C63BE500AD682A /* AudioPause.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioPause.png; sourceTree = "<group>"; };
+		49EB4C7A18C63BE500AD682A /* AudioPlay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioPlay.png; sourceTree = "<group>"; };
+		49EB4C7B18C63BE500AD682A /* AudioRecord.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioRecord.png; sourceTree = "<group>"; };
+		49EB4C7C18C63BE500AD682A /* AudioStop.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AudioStop.png; sourceTree = "<group>"; };
+		49EB4C7D18C63BE500AD682A /* DiskImage.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = DiskImage.icns; sourceTree = "<group>"; };
+		49EB4C7E18C63BE500AD682A /* Emulation.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Emulation.icns; sourceTree = "<group>"; };
+		49EB4C7F18C63BE500AD682A /* EmulationShow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationShow.png; sourceTree = "<group>"; };
+		49EB4C8018C63BE500AD682A /* EmulationShowPressed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationShowPressed.png; sourceTree = "<group>"; };
+		49EB4C8118C63BE500AD682A /* EmulationShowRollover.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationShowRollover.png; sourceTree = "<group>"; };
+		49EB4C8218C63BE500AD682A /* EmulationShowSelected.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationShowSelected.png; sourceTree = "<group>"; };
+		49EB4C8318C63BE500AD682A /* EmulationUnmount.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationUnmount.png; sourceTree = "<group>"; };
+		49EB4C8418C63BE500AD682A /* EmulationUnmountPressed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationUnmountPressed.png; sourceTree = "<group>"; };
+		49EB4C8518C63BE500AD682A /* EmulationUnmountRollover.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationUnmountRollover.png; sourceTree = "<group>"; };
+		49EB4C8618C63BE500AD682A /* EmulationUnmountSelected.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = EmulationUnmountSelected.png; sourceTree = "<group>"; };
+		49EB4C8718C63BE500AD682A /* IconAudio.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconAudio.png; sourceTree = "<group>"; };
+		49EB4C8818C63BE500AD682A /* IconColdRestart.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconColdRestart.png; sourceTree = "<group>"; };
+		49EB4C8918C63BE500AD682A /* IconDebuggerBreak.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconDebuggerBreak.png; sourceTree = "<group>"; };
+		49EB4C8A18C63BE500AD682A /* IconDevices.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconDevices.png; sourceTree = "<group>"; };
+		49EB4C8B18C63BE500AD682A /* IconGeneral.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconGeneral.png; sourceTree = "<group>"; };
+		49EB4C8C18C63BE500AD682A /* IconInspector.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconInspector.png; sourceTree = "<group>"; };
+		49EB4C8D18C63BE500AD682A /* IconLibrary.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconLibrary.png; sourceTree = "<group>"; };
+		49EB4C8E18C63BE500AD682A /* IconPowerDown.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconPowerDown.png; sourceTree = "<group>"; };
+		49EB4C8F18C63BE500AD682A /* IconRevert.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconRevert.png; sourceTree = "<group>"; };
+		49EB4C9018C63BE500AD682A /* IconSleep.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconSleep.png; sourceTree = "<group>"; };
+		49EB4C9118C63BE500AD682A /* IconVideo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconVideo.png; sourceTree = "<group>"; };
+		49EB4C9218C63BE500AD682A /* IconWakeUp.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconWakeUp.png; sourceTree = "<group>"; };
+		49EB4C9318C63BE500AD682A /* IconWarmRestart.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = IconWarmRestart.png; sourceTree = "<group>"; };
+		49EB4C9418C63BE500AD682A /* OpenEmulator.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = OpenEmulator.icns; sourceTree = "<group>"; };
+		49EB4C9518C63BE500AD682A /* ToolbarBackground.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ToolbarBackground.png; sourceTree = "<group>"; };
+		49EB4C9618C63BE500AD682A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		49EB4C9718C63BE500AD682A /* LibraryItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryItem.h; sourceTree = "<group>"; };
+		49EB4C9818C63BE500AD682A /* LibraryItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LibraryItem.mm; sourceTree = "<group>"; };
+		49EB4C9918C63BE500AD682A /* LibraryTableCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryTableCell.h; sourceTree = "<group>"; };
+		49EB4C9A18C63BE500AD682A /* LibraryTableCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibraryTableCell.m; sourceTree = "<group>"; };
+		49EB4C9B18C63BE500AD682A /* LibraryTableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryTableView.h; sourceTree = "<group>"; };
+		49EB4C9C18C63BE500AD682A /* LibraryTableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibraryTableView.m; sourceTree = "<group>"; };
+		49EB4C9D18C63BE500AD682A /* LibraryWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryWindowController.h; sourceTree = "<group>"; };
+		49EB4C9E18C63BE500AD682A /* LibraryWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibraryWindowController.m; sourceTree = "<group>"; };
+		49EB4C9F18C63BE500AD682A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		49EB4CA018C63BE500AD682A /* NSStringAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSStringAdditions.h; sourceTree = "<group>"; };
+		49EB4CA118C63BE500AD682A /* NSStringAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NSStringAdditions.mm; sourceTree = "<group>"; };
+		49EB4CA218C63BE500AD682A /* OpenEmulator_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenEmulator_Prefix.pch; sourceTree = "<group>"; };
+		49EB4CA318C63BE500AD682A /* PreferencesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreferencesWindowController.h; sourceTree = "<group>"; };
+		49EB4CA418C63BE500AD682A /* PreferencesWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PreferencesWindowController.m; sourceTree = "<group>"; };
+		49EB4CA618C63BE500AD682A /* sparkle_dsa_pub.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sparkle_dsa_pub.pem; sourceTree = "<group>"; };
+		49EB4CA718C63BE500AD682A /* TemplateChooserItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemplateChooserItem.h; sourceTree = "<group>"; };
+		49EB4CA818C63BE500AD682A /* TemplateChooserItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TemplateChooserItem.mm; sourceTree = "<group>"; };
+		49EB4CA918C63BE500AD682A /* TemplateChooserViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemplateChooserViewController.h; sourceTree = "<group>"; };
+		49EB4CAA18C63BE500AD682A /* TemplateChooserViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TemplateChooserViewController.m; sourceTree = "<group>"; };
+		49EB4CAB18C63BE500AD682A /* TemplateChooserWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemplateChooserWindowController.h; sourceTree = "<group>"; };
+		49EB4CAC18C63BE500AD682A /* TemplateChooserWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TemplateChooserWindowController.m; sourceTree = "<group>"; };
+		49EB4CAD18C63BE500AD682A /* VerticallyCenteredTextFieldCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VerticallyCenteredTextFieldCell.h; sourceTree = "<group>"; };
+		49EB4CAE18C63BE500AD682A /* VerticallyCenteredTextFieldCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VerticallyCenteredTextFieldCell.m; sourceTree = "<group>"; };
+		49EB4CF818C6536000AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = AudioControls.xib; sourceTree = "<group>"; };
+		49EB4CFA18C6536000AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = Canvas.xib; sourceTree = "<group>"; };
+		49EB4CFC18C6536000AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = Emulation.xib; sourceTree = "<group>"; };
+		49EB4CFE18C6536000AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = Library.xib; sourceTree = "<group>"; };
+		49EB4D0018C6536000AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = MainMenu.xib; sourceTree = "<group>"; };
+		49EB4D0218C6536100AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = Preferences.xib; sourceTree = "<group>"; };
+		49EB4D0418C6536100AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = TemplateChooser.xib; sourceTree = "<group>"; };
+		49EB4D0618C6536100AD682A /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = TemplateChooserView.xib; sourceTree = "<group>"; };
+		49EB4D1318C65CD500AD682A /* libpng16.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpng16.a; path = /opt/local/lib/libpng16.a; sourceTree = "<absolute>"; };
+		49EB4D2618C66FDD00AD682A /* DI2IMGBackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DI2IMGBackingStore.cpp; path = lib/libdiskimage/DI2IMGBackingStore.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D2718C66FDD00AD682A /* DI2IMGBackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DI2IMGBackingStore.h; path = lib/libdiskimage/DI2IMGBackingStore.h; sourceTree = SOURCE_ROOT; };
+		49EB4D2818C66FDD00AD682A /* DIApple35DiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIApple35DiskStorage.cpp; path = lib/libdiskimage/DIApple35DiskStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D2918C66FDD00AD682A /* DIApple35DiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIApple35DiskStorage.h; path = lib/libdiskimage/DIApple35DiskStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D2A18C66FDD00AD682A /* DIApple525DiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIApple525DiskStorage.cpp; path = lib/libdiskimage/DIApple525DiskStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D2B18C66FDD00AD682A /* DIApple525DiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIApple525DiskStorage.h; path = lib/libdiskimage/DIApple525DiskStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D2C18C66FDD00AD682A /* DIATABlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIATABlockStorage.cpp; path = lib/libdiskimage/DIATABlockStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D2D18C66FDD00AD682A /* DIATABlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIATABlockStorage.h; path = lib/libdiskimage/DIATABlockStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D2E18C66FDD00AD682A /* DIBackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIBackingStore.cpp; path = lib/libdiskimage/DIBackingStore.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D2F18C66FDD00AD682A /* DIBackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIBackingStore.h; path = lib/libdiskimage/DIBackingStore.h; sourceTree = SOURCE_ROOT; };
+		49EB4D3018C66FDD00AD682A /* DIBlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIBlockStorage.cpp; path = lib/libdiskimage/DIBlockStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D3118C66FDD00AD682A /* DIBlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIBlockStorage.h; path = lib/libdiskimage/DIBlockStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D3218C66FDD00AD682A /* DICommon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DICommon.cpp; path = lib/libdiskimage/DICommon.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D3318C66FDD00AD682A /* DICommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DICommon.h; path = lib/libdiskimage/DICommon.h; sourceTree = SOURCE_ROOT; };
+		49EB4D3418C66FDD00AD682A /* DIDC42BackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIDC42BackingStore.cpp; path = lib/libdiskimage/DIDC42BackingStore.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D3518C66FDD00AD682A /* DIDC42BackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIDC42BackingStore.h; path = lib/libdiskimage/DIDC42BackingStore.h; sourceTree = SOURCE_ROOT; };
+		49EB4D3618C66FDD00AD682A /* DIDDLDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIDDLDiskStorage.cpp; path = lib/libdiskimage/DIDDLDiskStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D3718C66FDD00AD682A /* DIDDLDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIDDLDiskStorage.h; path = lib/libdiskimage/DIDDLDiskStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D3818C66FDD00AD682A /* DIDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIDiskStorage.cpp; path = lib/libdiskimage/DIDiskStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D3918C66FDD00AD682A /* DIDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIDiskStorage.h; path = lib/libdiskimage/DIDiskStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D3A18C66FDD00AD682A /* DIFDIDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIFDIDiskStorage.cpp; path = lib/libdiskimage/DIFDIDiskStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D3B18C66FDD00AD682A /* DIFDIDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIFDIDiskStorage.h; path = lib/libdiskimage/DIFDIDiskStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D3C18C66FDD00AD682A /* DIFileBackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIFileBackingStore.cpp; path = lib/libdiskimage/DIFileBackingStore.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D3D18C66FDD00AD682A /* DIFileBackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIFileBackingStore.h; path = lib/libdiskimage/DIFileBackingStore.h; sourceTree = SOURCE_ROOT; };
+		49EB4D3E18C66FDD00AD682A /* DILogicalDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DILogicalDiskStorage.cpp; path = lib/libdiskimage/DILogicalDiskStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D3F18C66FDD00AD682A /* DILogicalDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DILogicalDiskStorage.h; path = lib/libdiskimage/DILogicalDiskStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D4018C66FDD00AD682A /* DIRAMBackingStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIRAMBackingStore.cpp; path = lib/libdiskimage/DIRAMBackingStore.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D4118C66FDD00AD682A /* DIRAMBackingStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIRAMBackingStore.h; path = lib/libdiskimage/DIRAMBackingStore.h; sourceTree = SOURCE_ROOT; };
+		49EB4D4218C66FDD00AD682A /* DIRAWBlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIRAWBlockStorage.cpp; path = lib/libdiskimage/DIRAWBlockStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D4318C66FDD00AD682A /* DIRAWBlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIRAWBlockStorage.h; path = lib/libdiskimage/DIRAWBlockStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D4418C66FDD00AD682A /* diskimage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = diskimage.h; path = lib/libdiskimage/diskimage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D4518C66FDD00AD682A /* DIV2DDiskStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIV2DDiskStorage.cpp; path = lib/libdiskimage/DIV2DDiskStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D4618C66FDD00AD682A /* DIV2DDiskStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIV2DDiskStorage.h; path = lib/libdiskimage/DIV2DDiskStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D4718C66FDD00AD682A /* DIVDIBlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIVDIBlockStorage.cpp; path = lib/libdiskimage/DIVDIBlockStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D4818C66FDD00AD682A /* DIVDIBlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIVDIBlockStorage.h; path = lib/libdiskimage/DIVDIBlockStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D4918C66FDD00AD682A /* DIVMDKBlockStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIVMDKBlockStorage.cpp; path = lib/libdiskimage/DIVMDKBlockStorage.cpp; sourceTree = SOURCE_ROOT; };
+		49EB4D4A18C66FDD00AD682A /* DIVMDKBlockStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIVMDKBlockStorage.h; path = lib/libdiskimage/DIVMDKBlockStorage.h; sourceTree = SOURCE_ROOT; };
+		49EB4D7118C6702100AD682A /* OECommon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OECommon.cpp; sourceTree = "<group>"; };
+		49EB4D7218C6702100AD682A /* OECommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OECommon.h; sourceTree = "<group>"; };
+		49EB4D7318C6702100AD682A /* OEComponent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEComponent.cpp; sourceTree = "<group>"; };
+		49EB4D7418C6702100AD682A /* OEComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEComponent.h; sourceTree = "<group>"; };
+		49EB4D7518C6702100AD682A /* OEComponentFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEComponentFactory.cpp; sourceTree = "<group>"; };
+		49EB4D7618C6702100AD682A /* OEComponentFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEComponentFactory.h; sourceTree = "<group>"; };
+		49EB4D7718C6702100AD682A /* OEDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEDevice.cpp; sourceTree = "<group>"; };
+		49EB4D7818C6702100AD682A /* OEDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDevice.h; sourceTree = "<group>"; };
+		49EB4D7918C6702100AD682A /* OEDocument.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEDocument.cpp; sourceTree = "<group>"; };
+		49EB4D7A18C6702100AD682A /* OEDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEDocument.h; sourceTree = "<group>"; };
+		49EB4D7B18C6702100AD682A /* OEEmulation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEEmulation.cpp; sourceTree = "<group>"; };
+		49EB4D7C18C6702100AD682A /* OEEmulation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEEmulation.h; sourceTree = "<group>"; };
+		49EB4D7D18C6702100AD682A /* OEImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEImage.cpp; sourceTree = "<group>"; };
+		49EB4D7E18C6702100AD682A /* OEImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEImage.h; sourceTree = "<group>"; };
+		49EB4D7F18C6702100AD682A /* OEPackage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OEPackage.cpp; sourceTree = "<group>"; };
+		49EB4D8018C6702100AD682A /* OEPackage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEPackage.h; sourceTree = "<group>"; };
+		49EB4D8118C6702100AD682A /* OESound.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OESound.cpp; sourceTree = "<group>"; };
+		49EB4D8218C6702100AD682A /* OESound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OESound.h; sourceTree = "<group>"; };
+		49EB4D8318C6702100AD682A /* ddl-1.0.dtd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = "ddl-1.0.dtd"; path = "lib/libemulation/ddl-1.0.dtd"; sourceTree = SOURCE_ROOT; };
+		49EB4D8418C6702100AD682A /* edl-1.0.dtd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = "edl-1.0.dtd"; path = "lib/libemulation/edl-1.0.dtd"; sourceTree = SOURCE_ROOT; };
+		49EB4D8718C6702100AD682A /* Apple1ACI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Apple1ACI.cpp; sourceTree = "<group>"; };
+		49EB4D8818C6702100AD682A /* Apple1ACI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Apple1ACI.h; sourceTree = "<group>"; };
+		49EB4D8918C6702100AD682A /* Apple1IO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Apple1IO.cpp; sourceTree = "<group>"; };
+		49EB4D8A18C6702100AD682A /* Apple1IO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Apple1IO.h; sourceTree = "<group>"; };
+		49EB4D8B18C6702100AD682A /* Apple1Terminal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Apple1Terminal.cpp; sourceTree = "<group>"; };
+		49EB4D8C18C6702100AD682A /* Apple1Terminal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Apple1Terminal.h; sourceTree = "<group>"; };
+		49EB4D8D18C6702100AD682A /* AppleDiskDrive525.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleDiskDrive525.cpp; sourceTree = "<group>"; };
+		49EB4D8E18C6702100AD682A /* AppleDiskDrive525.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleDiskDrive525.h; sourceTree = "<group>"; };
+		49EB4D8F18C6702100AD682A /* AppleDiskIIInterfaceCard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleDiskIIInterfaceCard.cpp; sourceTree = "<group>"; };
+		49EB4D9018C6702100AD682A /* AppleDiskIIInterfaceCard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleDiskIIInterfaceCard.h; sourceTree = "<group>"; };
+		49EB4D9118C6702100AD682A /* AppleGraphicsTablet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleGraphicsTablet.cpp; sourceTree = "<group>"; };
+		49EB4D9218C6702100AD682A /* AppleGraphicsTablet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleGraphicsTablet.h; sourceTree = "<group>"; };
+		49EB4D9318C6702100AD682A /* AppleGraphicsTabletInterfaceCard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleGraphicsTabletInterfaceCard.cpp; sourceTree = "<group>"; };
+		49EB4D9418C6702100AD682A /* AppleGraphicsTabletInterfaceCard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleGraphicsTabletInterfaceCard.h; sourceTree = "<group>"; };
+		49EB4D9518C6702100AD682A /* AppleIIAddressDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIAddressDecoder.cpp; sourceTree = "<group>"; };
+		49EB4D9618C6702100AD682A /* AppleIIAddressDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIAddressDecoder.h; sourceTree = "<group>"; };
+		49EB4D9718C6702100AD682A /* AppleIIAudioIn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIAudioIn.cpp; sourceTree = "<group>"; };
+		49EB4D9818C6702100AD682A /* AppleIIAudioIn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIAudioIn.h; sourceTree = "<group>"; };
+		49EB4D9918C6702100AD682A /* AppleIIAudioOut.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIAudioOut.cpp; sourceTree = "<group>"; };
+		49EB4D9A18C6702100AD682A /* AppleIIAudioOut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIAudioOut.h; sourceTree = "<group>"; };
+		49EB4D9B18C6702100AD682A /* AppleIIDisableC800.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIDisableC800.cpp; sourceTree = "<group>"; };
+		49EB4D9C18C6702100AD682A /* AppleIIDisableC800.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIDisableC800.h; sourceTree = "<group>"; };
+		49EB4D9D18C6702100AD682A /* AppleIIFloatingBus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIFloatingBus.cpp; sourceTree = "<group>"; };
+		49EB4D9E18C6702100AD682A /* AppleIIFloatingBus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIFloatingBus.h; sourceTree = "<group>"; };
+		49EB4D9F18C6702100AD682A /* AppleIIGamePort.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIGamePort.cpp; sourceTree = "<group>"; };
+		49EB4DA018C6702100AD682A /* AppleIIGamePort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIGamePort.h; sourceTree = "<group>"; };
+		49EB4DA118C6702100AD682A /* AppleIIIAddressDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIAddressDecoder.cpp; sourceTree = "<group>"; };
+		49EB4DA218C6702100AD682A /* AppleIIIAddressDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIAddressDecoder.h; sourceTree = "<group>"; };
+		49EB4DA318C6702100AD682A /* AppleIIIBeeper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIBeeper.cpp; sourceTree = "<group>"; };
+		49EB4DA418C6702100AD682A /* AppleIIIBeeper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIBeeper.h; sourceTree = "<group>"; };
+		49EB4DA518C6702100AD682A /* AppleIIIDiskIO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIDiskIO.cpp; sourceTree = "<group>"; };
+		49EB4DA618C6702100AD682A /* AppleIIIDiskIO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIDiskIO.h; sourceTree = "<group>"; };
+		49EB4DA718C6702100AD682A /* AppleIIIGamePort.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIGamePort.cpp; sourceTree = "<group>"; };
+		49EB4DA818C6702100AD682A /* AppleIIIGamePort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIGamePort.h; sourceTree = "<group>"; };
+		49EB4DA918C6702100AD682A /* AppleIIIKeyboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIKeyboard.cpp; sourceTree = "<group>"; };
+		49EB4DAA18C6702100AD682A /* AppleIIIKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIKeyboard.h; sourceTree = "<group>"; };
+		49EB4DAB18C6702100AD682A /* AppleIIIMOS6502.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIMOS6502.cpp; sourceTree = "<group>"; };
+		49EB4DAC18C6702100AD682A /* AppleIIIMOS6502.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIMOS6502.h; sourceTree = "<group>"; };
+		49EB4DAD18C6702100AD682A /* AppleIIIMOS6502Opcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIMOS6502Opcodes.h; sourceTree = "<group>"; };
+		49EB4DAE18C6702100AD682A /* AppleIIIMOS6502Operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIMOS6502Operations.h; sourceTree = "<group>"; };
+		49EB4DAF18C6702100AD682A /* AppleIIIRTC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIRTC.cpp; sourceTree = "<group>"; };
+		49EB4DB018C6702100AD682A /* AppleIIIRTC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIRTC.h; sourceTree = "<group>"; };
+		49EB4DB118C6702100AD682A /* AppleIIISystemControl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIISystemControl.cpp; sourceTree = "<group>"; };
+		49EB4DB218C6702100AD682A /* AppleIIISystemControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIISystemControl.h; sourceTree = "<group>"; };
+		49EB4DB318C6702100AD682A /* AppleIIIVideo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIIVideo.cpp; sourceTree = "<group>"; };
+		49EB4DB418C6702100AD682A /* AppleIIIVideo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIVideo.h; sourceTree = "<group>"; };
+		49EB4DB518C6702100AD682A /* AppleIIKeyboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIKeyboard.cpp; sourceTree = "<group>"; };
+		49EB4DB618C6702100AD682A /* AppleIIKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIKeyboard.h; sourceTree = "<group>"; };
+		49EB4DB718C6702100AD682A /* AppleIISlotController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIISlotController.cpp; sourceTree = "<group>"; };
+		49EB4DB818C6702100AD682A /* AppleIISlotController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIISlotController.h; sourceTree = "<group>"; };
+		49EB4DB918C6702100AD682A /* AppleIISystemControl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIISystemControl.cpp; sourceTree = "<group>"; };
+		49EB4DBA18C6702100AD682A /* AppleIISystemControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIISystemControl.h; sourceTree = "<group>"; };
+		49EB4DBB18C6702100AD682A /* AppleIIVideo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleIIVideo.cpp; sourceTree = "<group>"; };
+		49EB4DBC18C6702100AD682A /* AppleIIVideo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIVideo.h; sourceTree = "<group>"; };
+		49EB4DBD18C6702100AD682A /* AppleLanguageCard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleLanguageCard.cpp; sourceTree = "<group>"; };
+		49EB4DBE18C6702100AD682A /* AppleLanguageCard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleLanguageCard.h; sourceTree = "<group>"; };
+		49EB4DBF18C6702100AD682A /* AppleSilentype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleSilentype.cpp; sourceTree = "<group>"; };
+		49EB4DC018C6702100AD682A /* AppleSilentype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleSilentype.h; sourceTree = "<group>"; };
+		49EB4DC118C6702100AD682A /* AppleSilentypeInterfaceCard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppleSilentypeInterfaceCard.cpp; sourceTree = "<group>"; };
+		49EB4DC218C6702100AD682A /* AppleSilentypeInterfaceCard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleSilentypeInterfaceCard.h; sourceTree = "<group>"; };
+		49EB4DC418C6702100AD682A /* AddressDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressDecoder.cpp; sourceTree = "<group>"; };
+		49EB4DC518C6702100AD682A /* AddressDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressDecoder.h; sourceTree = "<group>"; };
+		49EB4DC618C6702100AD682A /* AddressMapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressMapper.cpp; sourceTree = "<group>"; };
+		49EB4DC718C6702100AD682A /* AddressMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressMapper.h; sourceTree = "<group>"; };
+		49EB4DC818C6702100AD682A /* AddressMasker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressMasker.cpp; sourceTree = "<group>"; };
+		49EB4DC918C6702100AD682A /* AddressMasker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressMasker.h; sourceTree = "<group>"; };
+		49EB4DCA18C6702100AD682A /* AddressMux.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressMux.cpp; sourceTree = "<group>"; };
+		49EB4DCB18C6702100AD682A /* AddressMux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressMux.h; sourceTree = "<group>"; };
+		49EB4DCC18C6702100AD682A /* AddressOffset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddressOffset.cpp; sourceTree = "<group>"; };
+		49EB4DCD18C6702100AD682A /* AddressOffset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressOffset.h; sourceTree = "<group>"; };
+		49EB4DCE18C6702100AD682A /* ATAController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ATAController.cpp; sourceTree = "<group>"; };
+		49EB4DCF18C6702100AD682A /* ATAController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATAController.h; sourceTree = "<group>"; };
+		49EB4DD018C6702200AD682A /* ATADevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ATADevice.cpp; sourceTree = "<group>"; };
+		49EB4DD118C6702200AD682A /* ATADevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATADevice.h; sourceTree = "<group>"; };
+		49EB4DD218C6702200AD682A /* Audio1Bit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Audio1Bit.cpp; sourceTree = "<group>"; };
+		49EB4DD318C6702200AD682A /* Audio1Bit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Audio1Bit.h; sourceTree = "<group>"; };
+		49EB4DD418C6702200AD682A /* AudioCodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioCodec.cpp; sourceTree = "<group>"; };
+		49EB4DD518C6702200AD682A /* AudioCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioCodec.h; sourceTree = "<group>"; };
+		49EB4DD618C6702200AD682A /* AudioPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioPlayer.cpp; sourceTree = "<group>"; };
+		49EB4DD718C6702200AD682A /* AudioPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioPlayer.h; sourceTree = "<group>"; };
+		49EB4DD818C6702200AD682A /* ControlBus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ControlBus.cpp; sourceTree = "<group>"; };
+		49EB4DD918C6702200AD682A /* ControlBus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ControlBus.h; sourceTree = "<group>"; };
+		49EB4DDA18C6702200AD682A /* FloatingBus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatingBus.cpp; sourceTree = "<group>"; };
+		49EB4DDB18C6702200AD682A /* FloatingBus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FloatingBus.h; sourceTree = "<group>"; };
+		49EB4DDC18C6702200AD682A /* JoystickMapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JoystickMapper.cpp; sourceTree = "<group>"; };
+		49EB4DDD18C6702200AD682A /* JoystickMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JoystickMapper.h; sourceTree = "<group>"; };
+		49EB4DDE18C6702200AD682A /* Monitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Monitor.cpp; sourceTree = "<group>"; };
+		49EB4DDF18C6702200AD682A /* Monitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Monitor.h; sourceTree = "<group>"; };
+		49EB4DE018C6702200AD682A /* Proxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Proxy.cpp; sourceTree = "<group>"; };
+		49EB4DE118C6702200AD682A /* Proxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Proxy.h; sourceTree = "<group>"; };
+		49EB4DE218C6702200AD682A /* RAM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RAM.cpp; sourceTree = "<group>"; };
+		49EB4DE318C6702200AD682A /* RAM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RAM.h; sourceTree = "<group>"; };
+		49EB4DE418C6702200AD682A /* ROM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ROM.cpp; sourceTree = "<group>"; };
+		49EB4DE518C6702200AD682A /* ROM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ROM.h; sourceTree = "<group>"; };
+		49EB4DE618C6702200AD682A /* VRAM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VRAM.cpp; sourceTree = "<group>"; };
+		49EB4DE718C6702200AD682A /* VRAM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VRAM.h; sourceTree = "<group>"; };
+		49EB4DE918C6702200AD682A /* MOS6502.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOS6502.cpp; sourceTree = "<group>"; };
+		49EB4DEA18C6702200AD682A /* MOS6502.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6502.h; sourceTree = "<group>"; };
+		49EB4DEB18C6702200AD682A /* MOS6502IllegalOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6502IllegalOperations.h; sourceTree = "<group>"; };
+		49EB4DEC18C6702200AD682A /* MOS6502Opcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6502Opcodes.h; sourceTree = "<group>"; };
+		49EB4DED18C6702200AD682A /* MOS6502Operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6502Operations.h; sourceTree = "<group>"; };
+		49EB4DF218C6702200AD682A /* MOS6522.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOS6522.cpp; sourceTree = "<group>"; };
+		49EB4DF318C6702200AD682A /* MOS6522.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6522.h; sourceTree = "<group>"; };
+		49EB4DF418C6702200AD682A /* MOS6530.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOS6530.cpp; sourceTree = "<group>"; };
+		49EB4DF518C6702200AD682A /* MOS6530.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6530.h; sourceTree = "<group>"; };
+		49EB4DF618C6702200AD682A /* MOS6551.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOS6551.cpp; sourceTree = "<group>"; };
+		49EB4DF718C6702200AD682A /* MOS6551.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOS6551.h; sourceTree = "<group>"; };
+		49EB4DF818C6702200AD682A /* MOSKIM1IO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOSKIM1IO.cpp; sourceTree = "<group>"; };
+		49EB4DF918C6702200AD682A /* MOSKIM1IO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOSKIM1IO.h; sourceTree = "<group>"; };
+		49EB4DFA18C6702200AD682A /* MOSKIM1PLL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MOSKIM1PLL.cpp; sourceTree = "<group>"; };
+		49EB4DFB18C6702200AD682A /* MOSKIM1PLL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOSKIM1PLL.h; sourceTree = "<group>"; };
+		49EB4DFD18C6702200AD682A /* MC6821.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MC6821.cpp; sourceTree = "<group>"; };
+		49EB4DFE18C6702200AD682A /* MC6821.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MC6821.h; sourceTree = "<group>"; };
+		49EB4DFF18C6702200AD682A /* MC6845.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MC6845.cpp; sourceTree = "<group>"; };
+		49EB4E0018C6702200AD682A /* MC6845.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MC6845.h; sourceTree = "<group>"; };
+		49EB4E0218C6702200AD682A /* MM58167.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MM58167.cpp; sourceTree = "<group>"; };
+		49EB4E0318C6702200AD682A /* MM58167.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MM58167.h; sourceTree = "<group>"; };
+		49EB4E0518C6702200AD682A /* RDCFFA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RDCFFA.cpp; sourceTree = "<group>"; };
+		49EB4E0618C6702200AD682A /* RDCFFA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RDCFFA.h; sourceTree = "<group>"; };
+		49EB4E0E18C6702200AD682A /* VidexVideoterm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VidexVideoterm.cpp; sourceTree = "<group>"; };
+		49EB4E0F18C6702200AD682A /* VidexVideoterm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VidexVideoterm.h; sourceTree = "<group>"; };
+		49EB4E1118C6702200AD682A /* W65C02S.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = W65C02S.cpp; sourceTree = "<group>"; };
+		49EB4E1218C6702200AD682A /* W65C02S.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W65C02S.h; sourceTree = "<group>"; };
+		49EB4E1318C6702200AD682A /* W65C02SOpcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W65C02SOpcodes.h; sourceTree = "<group>"; };
+		49EB4E1418C6702200AD682A /* W65C02SOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W65C02SOperations.h; sourceTree = "<group>"; };
+		49EB4E1518C6702200AD682A /* W65C816S.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = W65C816S.cpp; sourceTree = "<group>"; };
+		49EB4E1618C6702200AD682A /* W65C816S.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = W65C816S.h; sourceTree = "<group>"; };
+		49EB4E1E18C6702200AD682A /* AppleIIIInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIIInterface.h; sourceTree = "<group>"; };
+		49EB4E1F18C6702200AD682A /* AppleIIInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppleIIInterface.h; sourceTree = "<group>"; };
+		49EB4E2118C6702200AD682A /* RS232Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RS232Interface.h; sourceTree = "<group>"; };
+		49EB4E2318C6702200AD682A /* AudioPlayerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioPlayerInterface.h; sourceTree = "<group>"; };
+		49EB4E2418C6702200AD682A /* ControlBusInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ControlBusInterface.h; sourceTree = "<group>"; };
+		49EB4E2518C6702200AD682A /* CPUInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUInterface.h; sourceTree = "<group>"; };
+		49EB4E2618C6702200AD682A /* MemoryInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryInterface.cpp; sourceTree = "<group>"; };
+		49EB4E2718C6702200AD682A /* MemoryInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryInterface.h; sourceTree = "<group>"; };
+		49EB4E2818C6702200AD682A /* PIAInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PIAInterface.h; sourceTree = "<group>"; };
+		49EB4E2A18C6702200AD682A /* AudioInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioInterface.cpp; sourceTree = "<group>"; };
+		49EB4E2B18C6702200AD682A /* AudioInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioInterface.h; sourceTree = "<group>"; };
+		49EB4E2C18C6702200AD682A /* CanvasInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasInterface.h; sourceTree = "<group>"; };
+		49EB4E2D18C6702200AD682A /* DeviceInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceInterface.h; sourceTree = "<group>"; };
+		49EB4E2E18C6702200AD682A /* EmulationInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationInterface.h; sourceTree = "<group>"; };
+		49EB4E2F18C6702200AD682A /* EthernetInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EthernetInterface.h; sourceTree = "<group>"; };
+		49EB4E3018C6702200AD682A /* JoystickInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JoystickInterface.h; sourceTree = "<group>"; };
+		49EB4E3118C6702200AD682A /* MIDIInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MIDIInterface.h; sourceTree = "<group>"; };
+		49EB4E3218C6702200AD682A /* StorageInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageInterface.h; sourceTree = "<group>"; };
+		49EB4E3318C6702200AD682A /* USBInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = USBInterface.h; sourceTree = "<group>"; };
+		49EB4E3418C6702200AD682A /* VideoCaptureInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoCaptureInterface.h; sourceTree = "<group>"; };
+		49EB4E3618C6702200AD682A /* IEEE1284Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IEEE1284Interface.h; sourceTree = "<group>"; };
+		49EB4E3718C6702200AD682A /* IEEE1394Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IEEE1394Interface.h; sourceTree = "<group>"; };
+		49EB4E3818C6702200AD682A /* IEEE488Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IEEE488Interface.h; sourceTree = "<group>"; };
+		49EB4EEE18C6709F00AD682A /* HIDJoystick.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HIDJoystick.cpp; path = "lib/libemulation-hal/HIDJoystick.cpp"; sourceTree = SOURCE_ROOT; };
+		49EB4EEF18C6709F00AD682A /* HIDJoystick.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HIDJoystick.h; path = "lib/libemulation-hal/HIDJoystick.h"; sourceTree = SOURCE_ROOT; };
+		49EB4EF018C6709F00AD682A /* OEMatrix3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OEMatrix3.cpp; path = "lib/libemulation-hal/OEMatrix3.cpp"; sourceTree = SOURCE_ROOT; };
+		49EB4EF118C6709F00AD682A /* OEMatrix3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OEMatrix3.h; path = "lib/libemulation-hal/OEMatrix3.h"; sourceTree = SOURCE_ROOT; };
+		49EB4EF218C6709F00AD682A /* OEVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OEVector.cpp; path = "lib/libemulation-hal/OEVector.cpp"; sourceTree = SOURCE_ROOT; };
+		49EB4EF318C6709F00AD682A /* OEVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OEVector.h; path = "lib/libemulation-hal/OEVector.h"; sourceTree = SOURCE_ROOT; };
+		49EB4EF418C6709F00AD682A /* OpenGLCanvas.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OpenGLCanvas.cpp; path = "lib/libemulation-hal/OpenGLCanvas.cpp"; sourceTree = SOURCE_ROOT; };
+		49EB4EF518C6709F00AD682A /* OpenGLCanvas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OpenGLCanvas.h; path = "lib/libemulation-hal/OpenGLCanvas.h"; sourceTree = SOURCE_ROOT; };
+		49EB4EF618C6709F00AD682A /* PAAudio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PAAudio.cpp; path = "lib/libemulation-hal/PAAudio.cpp"; sourceTree = SOURCE_ROOT; };
+		49EB4EF718C6709F00AD682A /* PAAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PAAudio.h; path = "lib/libemulation-hal/PAAudio.h"; sourceTree = SOURCE_ROOT; };
+		49EB4F0618C6737700AD682A /* util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = util.cpp; path = lib/libutil/util.cpp; sourceTree = "<group>"; };
+		49EB4F0718C6737700AD682A /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = util.h; path = lib/libutil/util.h; sourceTree = "<group>"; };
 		8D15AC370486D014006FF6A4 /* OpenEmulator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenEmulator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -743,6 +772,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49EB4D1518C65CD500AD682A /* libpng16.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -761,7 +791,6 @@
 				00039E9B12B042210025D374 /* libemulation-hal.a in Frameworks */,
 				00365CFA1516F4E700978DF6 /* libdiskimage.a in Frameworks */,
 				00CF208215B0DB5700DA8E08 /* libutil.a in Frameworks */,
-				001F56F90FD1E8E500EA246A /* Sparkle.framework in Frameworks */,
 				0054E4A11131BE7A006D32D9 /* Cocoa.framework in Frameworks */,
 				0054E4A71131BE8A006D32D9 /* OpenGL.framework in Frameworks */,
 				0054E6311131BEE7006D32D9 /* Carbon.framework in Frameworks */,
@@ -769,20 +798,20 @@
 				00F4D0BF12E2E42F00B7F5E6 /* ApplicationServices.framework in Frameworks */,
 				003B167C12EE27ED003FB8F6 /* CoreAudioKit.framework in Frameworks */,
 				003B16B212EE2A05003FB8F6 /* AudioToolbox.framework in Frameworks */,
+				49EB4C4318C63B1800AD682A /* libFLAC.dylib in Frameworks */,
 				003B16B712EE2A0D003FB8F6 /* AudioUnit.framework in Frameworks */,
 				003B16C312EE2A18003FB8F6 /* CoreAudio.framework in Frameworks */,
 				003B16C812EE2A61003FB8F6 /* CoreServices.framework in Frameworks */,
 				008CA97E147803E500B9F5D0 /* IOKit.framework in Frameworks */,
 				00039FD112B04F6C0025D374 /* libxml2.dylib in Frameworks */,
 				002F57E615CDF4AC00C19659 /* libz.a in Frameworks */,
+				49EB4D1418C65CD500AD682A /* libpng16.a in Frameworks */,
 				002F57E815CDF4B400C19659 /* libvorbis.a in Frameworks */,
 				002F57EA15CDF4B900C19659 /* libzip.a in Frameworks */,
 				002F57EC15CDF4C000C19659 /* libsndfile.a in Frameworks */,
 				002F57EE15CDF4C600C19659 /* libsamplerate.a in Frameworks */,
 				002F57F015CDF4CB00C19659 /* libportaudio.a in Frameworks */,
-				002F57F215CDF4D100C19659 /* libpng14.a in Frameworks */,
 				002F57F415CDF66B00C19659 /* libogg.a in Frameworks */,
-				002F57F615CDF6DF00C19659 /* libFLAC.a in Frameworks */,
 				002F57F815CDF6F800C19659 /* libvorbisenc.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -790,73 +819,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		00039E3C12B03BA90025D374 /* libemulation-hal */ = {
+		00039E3C12B03BA90025D374 /* emulation-hal */ = {
 			isa = PBXGroup;
 			children = (
-				008363051326C15300CB9A21 /* OpenGLCanvas.cpp */,
-				008363061326C15300CB9A21 /* OpenGLCanvas.h */,
-				008363091326C15300CB9A21 /* PAAudio.cpp */,
-				0083630A1326C15300CB9A21 /* PAAudio.h */,
-				008363071326C15300CB9A21 /* OEVector.cpp */,
-				008363081326C15300CB9A21 /* OEVector.h */,
-				00D226551350FF8B00FC69B9 /* OEMatrix3.cpp */,
-				00D226541350FF8B00FC69B9 /* OEMatrix3.h */,
-				00A12994147A8E7500DF323F /* HIDJoystick.cpp */,
-				00A12996147A8E7E00DF323F /* HIDJoystick.h */,
+				49EB4EEE18C6709F00AD682A /* HIDJoystick.cpp */,
+				49EB4EEF18C6709F00AD682A /* HIDJoystick.h */,
+				49EB4EF018C6709F00AD682A /* OEMatrix3.cpp */,
+				49EB4EF118C6709F00AD682A /* OEMatrix3.h */,
+				49EB4EF218C6709F00AD682A /* OEVector.cpp */,
+				49EB4EF318C6709F00AD682A /* OEVector.h */,
+				49EB4EF418C6709F00AD682A /* OpenGLCanvas.cpp */,
+				49EB4EF518C6709F00AD682A /* OpenGLCanvas.h */,
+				49EB4EF618C6709F00AD682A /* PAAudio.cpp */,
+				49EB4EF718C6709F00AD682A /* PAAudio.h */,
 			);
+			name = "emulation-hal";
 			path = "libemulation-hal";
 			sourceTree = "<group>";
 		};
 		000A78A50FBA464600A0F12E /* OpenEmulator.app */ = {
 			isa = PBXGroup;
 			children = (
-				2A37F4ABFDCFA73011CA2CEA /* Sources */,
-				2A37F4B8FDCFA73011CA2CEA /* Resources */,
+				49EB4C4818C63BE500AD682A /* src */,
 				2A37F4C3FDCFA73011CA2CEA /* Frameworks */,
 			);
 			name = OpenEmulator.app;
-			sourceTree = "<group>";
-		};
-		000A79070FBA49C500A0F12E /* Images */ = {
-			isa = PBXGroup;
-			children = (
-				007EF9C61570329D0073061E /* IconRevert.png */,
-				00391D6012D3B570002C5ABD /* IconLibrary.png */,
-				00ED379712779AD000BEF6BD /* AudioMax.png */,
-				00ED379812779AD000BEF6BD /* AudioMin.png */,
-				0076FD6412A1ED8C00A3FEC7 /* AudioPause.png */,
-				00ED379912779AD000BEF6BD /* AudioPlay.png */,
-				00ED379A12779AD000BEF6BD /* AudioRecord.png */,
-				00ED379B12779AD000BEF6BD /* AudioStop.png */,
-				00E442931278727600713A05 /* EmulationShow.png */,
-				00039CF212B01D530025D374 /* EmulationShowPressed.png */,
-				00039E0B12B0365A0025D374 /* EmulationShowRollover.png */,
-				00039D2512B01EB40025D374 /* EmulationShowSelected.png */,
-				00F01B4612A0D6EC000527CA /* EmulationUnmount.png */,
-				00039CEB12B01D530025D374 /* EmulationUnmountPressed.png */,
-				00039E0A12B0365A0025D374 /* EmulationUnmountRollover.png */,
-				00039D2412B01EB40025D374 /* EmulationUnmountSelected.png */,
-				00ED37A812779DD800BEF6BD /* IconAudio.png */,
-				00ED37A912779DD800BEF6BD /* IconColdRestart.png */,
-				00E442911278726B00713A05 /* IconDevices.png */,
-				00ED37AA12779DD800BEF6BD /* IconDebuggerBreak.png */,
-				00ED37AB12779DD800BEF6BD /* IconGeneral.png */,
-				00ED37AC12779DD800BEF6BD /* IconInspector.png */,
-				00ED37AD12779DD800BEF6BD /* IconPowerDown.png */,
-				00ED37AE12779DD800BEF6BD /* IconSleep.png */,
-				00ED37AF12779DD800BEF6BD /* IconVideo.png */,
-				00ED37B012779DD800BEF6BD /* IconWakeUp.png */,
-				00ED37B112779DD800BEF6BD /* IconWarmRestart.png */,
-				0073DDBE136FCCC900087303 /* ToolbarBackground.png */,
-				000F66370FF8368F00C8AF23 /* DiskImage.icns */,
-				000F663A0FF8368F00C8AF23 /* Emulation.icns */,
-				000F66520FF8368F00C8AF23 /* OpenEmulator.icns */,
-				0054868F0FDC817900DBCFA8 /* Emulation.icns */,
-				006EEE8F0FCA781C003D2C8D /* DiskImage.icns */,
-				000A79190FBA49C500A0F12E /* OpenEmulator.icns */,
-			);
-			name = Images;
-			path = macosx/Images;
 			sourceTree = "<group>";
 		};
 		001750AF13A50A690043E2ED /* Docs and Scripts */ = {
@@ -875,375 +862,71 @@
 			name = "Docs and Scripts";
 			sourceTree = "<group>";
 		};
-		001CC97D13D11E9900B0DDA7 /* Generic */ = {
+		00B8864512A3923D0052B7A4 /* emulation */ = {
 			isa = PBXGroup;
 			children = (
-				00936E8915177B60006B0EAC /* AudioPlayerInterface.h */,
-				0022236B142C557100B7451D /* ControlBusInterface.h */,
-				001CC97E13D11EBC00B0DDA7 /* CPUInterface.h */,
-				00A90FB2150D3A0000BB2999 /* MemoryInterface.cpp */,
-				00DC0E78145DFECD00FF51BD /* MemoryInterface.h */,
+				49EB4D7018C6702100AD682A /* Core */,
+				49EB4D8318C6702100AD682A /* ddl-1.0.dtd */,
+				49EB4D8418C6702100AD682A /* edl-1.0.dtd */,
+				49EB4D8518C6702100AD682A /* Implementation */,
+				49EB4E1C18C6702200AD682A /* Interface */,
 			);
-			path = Generic;
-			sourceTree = "<group>";
-		};
-		002740B513A08A1E00E13D65 /* Videx */ = {
-			isa = PBXGroup;
-			children = (
-				002740B613A08A4F00E13D65 /* VidexVideoterm.cpp */,
-				002740B713A08A4F00E13D65 /* VidexVideoterm.h */,
-			);
-			path = Videx;
-			sourceTree = "<group>";
-		};
-		0044FDCF15D377B800F82C28 /* National */ = {
-			isa = PBXGroup;
-			children = (
-				0044FDD315D3784500F82C28 /* MM58167.cpp */,
-				0044FDD415D3784500F82C28 /* MM58167.h */,
-			);
-			path = National;
-			sourceTree = "<group>";
-		};
-		00A9739D12E512F80084724F /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				00247F35139D85A900B165D1 /* OECommon.cpp */,
-				00247F36139D85AA00B165D1 /* OECommon.h */,
-				00A973A012E512F80084724F /* OEComponent.cpp */,
-				00A973A112E512F80084724F /* OEComponent.h */,
-				00A973A212E512F80084724F /* OEComponentFactory.cpp */,
-				00A973A312E512F80084724F /* OEComponentFactory.h */,
-				00B019B313501507001E01BB /* OEDevice.cpp */,
-				00B019B213501507001E01BB /* OEDevice.h */,
-				00A973A412E512F80084724F /* OEDocument.cpp */,
-				00A973A512E512F80084724F /* OEDocument.h */,
-				00A9739E12E512F80084724F /* OEEmulation.cpp */,
-				00A9739F12E512F80084724F /* OEEmulation.h */,
-				00A973A612E512F80084724F /* OEImage.cpp */,
-				00A973A712E512F80084724F /* OEImage.h */,
-				00A973A812E512F80084724F /* OEPackage.cpp */,
-				00A973A912E512F80084724F /* OEPackage.h */,
-				00AD7027151AC41E00424637 /* OESound.cpp */,
-				00AD7025151AC19100424637 /* OESound.h */,
-			);
-			path = Core;
-			sourceTree = "<group>";
-		};
-		00B8864512A3923D0052B7A4 /* libemulation */ = {
-			isa = PBXGroup;
-			children = (
-				00A9739D12E512F80084724F /* Core */,
-				00B8880F12A393990052B7A4 /* Implementation */,
-				00B8886912A393990052B7A4 /* Interface */,
-				00D6FB7B15B3CCD00063312F /* ddl-1.0.dtd */,
-				00B8864612A3923D0052B7A4 /* edl-1.0.dtd */,
-			);
+			name = emulation;
 			path = libemulation;
 			sourceTree = "<group>";
 		};
-		00B8880F12A393990052B7A4 /* Implementation */ = {
+		00CF206D15B0D8B400DA8E08 /* util */ = {
 			isa = PBXGroup;
 			children = (
-				00B8882D12A393990052B7A4 /* Generic */,
-				00B8881012A393990052B7A4 /* Apple */,
-				00B8884212A393990052B7A4 /* MOS */,
-				00B8885212A393990052B7A4 /* Motorola */,
-				0044FDCF15D377B800F82C28 /* National */,
-				00EA1F07159799A100079A54 /* RD */,
-				00B8885712A393990052B7A4 /* Ricoh */,
-				002740B513A08A1E00E13D65 /* Videx */,
-				00B8885D12A393990052B7A4 /* WDC */,
-				00B8886412A393990052B7A4 /* Zilog */,
+				49EB4F0618C6737700AD682A /* util.cpp */,
+				49EB4F0718C6737700AD682A /* util.h */,
 			);
-			path = Implementation;
+			name = util;
 			sourceTree = "<group>";
 		};
-		00B8881012A393990052B7A4 /* Apple */ = {
+		00E473201475689C00F367B7 /* diskimage */ = {
 			isa = PBXGroup;
 			children = (
-				00B8881312A393990052B7A4 /* Apple1ACI.cpp */,
-				00B8881412A393990052B7A4 /* Apple1ACI.h */,
-				00F397E3141655DA00C53A3E /* Apple1IO.cpp */,
-				00F397E5141655EB00C53A3E /* Apple1IO.h */,
-				00722D3B1470E31400FE7007 /* Apple1Terminal.cpp */,
-				00B8881812A393990052B7A4 /* Apple1Terminal.h */,
-				00044CA212CE6FD400D26940 /* AppleDiskDrive525.cpp */,
-				00044CA112CE6FD400D26940 /* AppleDiskDrive525.h */,
-				00811DFE12D251E9009AD2F0 /* AppleDiskIIInterfaceCard.cpp */,
-				00811DFD12D251E9009AD2F0 /* AppleDiskIIInterfaceCard.h */,
-				00811F1112D2738B009AD2F0 /* AppleGraphicsTablet.cpp */,
-				00811F1012D2738B009AD2F0 /* AppleGraphicsTablet.h */,
-				00379130157B285E0020138F /* AppleGraphicsTabletInterfaceCard.cpp */,
-				00379131157B285E0020138F /* AppleGraphicsTabletInterfaceCard.h */,
-				001E09691556339400405DC0 /* AppleLanguageCard.cpp */,
-				001E096A1556339400405DC0 /* AppleLanguageCard.h */,
-				00B5CB92136F0B6C007A7BED /* AppleSilentype.cpp */,
-				00B5CB93136F0B6C007A7BED /* AppleSilentype.h */,
-				005316C21596D268007F3C86 /* AppleSilentypeInterfaceCard.cpp */,
-				00AB963B157F9E8200EDACD5 /* AppleSilentypeInterfaceCard.h */,
-				00139F83151195E600B0E108 /* AppleIIAddressDecoder.cpp */,
-				00139F85151195EE00B0E108 /* AppleIIAddressDecoder.h */,
-				00B8881912A393990052B7A4 /* AppleIIAudioIn.cpp */,
-				00B8881A12A393990052B7A4 /* AppleIIAudioIn.h */,
-				00B8881B12A393990052B7A4 /* AppleIIAudioOut.cpp */,
-				00B8881C12A393990052B7A4 /* AppleIIAudioOut.h */,
-				00AB96A5158053BF00EDACD5 /* AppleIIDisableC800.cpp */,
-				00AB96A6158053C000EDACD5 /* AppleIIDisableC800.h */,
-				00B8881F12A393990052B7A4 /* AppleIIFloatingBus.cpp */,
-				00B8882012A393990052B7A4 /* AppleIIFloatingBus.h */,
-				00B7C649147B5B2B00BB7E6B /* AppleIIGamePort.cpp */,
-				00B7C647147B5B2300BB7E6B /* AppleIIGamePort.h */,
-				00B8882312A393990052B7A4 /* AppleIIKeyboard.cpp */,
-				00B8882412A393990052B7A4 /* AppleIIKeyboard.h */,
-				00B8882912A393990052B7A4 /* AppleIISlotController.cpp */,
-				00B8882A12A393990052B7A4 /* AppleIISlotController.h */,
-				008696AF15CB9047000737EE /* AppleIISystemControl.cpp */,
-				008696AE15CB903E000737EE /* AppleIISystemControl.h */,
-				00B8882B12A393990052B7A4 /* AppleIIVideo.cpp */,
-				00B8882C12A393990052B7A4 /* AppleIIVideo.h */,
-				007F6C3615CD05370004D4C4 /* AppleIIIAddressDecoder.cpp */,
-				007F6C3415CD052D0004D4C4 /* AppleIIIAddressDecoder.h */,
-				0077271F15D81387008AB5A2 /* AppleIIIBeeper.cpp */,
-				0077271D15D8137F008AB5A2 /* AppleIIIBeeper.h */,
-				008696AC15C8FC93000737EE /* AppleIIIDiskIO.cpp */,
-				008696AB15C8FC89000737EE /* AppleIIIDiskIO.h */,
-				007F6C3C15CD06930004D4C4 /* AppleIIIGamePort.cpp */,
-				007F6C3B15CD068C0004D4C4 /* AppleIIIGamePort.h */,
-				00D96F4B15E010AD0066EB0C /* AppleIIIKeyboard.cpp */,
-				00D96F4A15E010A30066EB0C /* AppleIIIKeyboard.h */,
-				0042498E15B693DE0091ECAB /* AppleIIIMOS6502.cpp */,
-				0042498F15B693DE0091ECAB /* AppleIIIMOS6502.h */,
-				0042499215B694A60091ECAB /* AppleIIIMOS6502Opcodes.h */,
-				0042499415B696EA0091ECAB /* AppleIIIMOS6502Operations.h */,
-				008CB9A615E7B08A00027B7B /* AppleIIIRTC.cpp */,
-				008CB9A415E7B08300027B7B /* AppleIIIRTC.h */,
-				004E152915B9041A00FD22AB /* AppleIIISystemControl.cpp */,
-				004E152C15B9042100FD22AB /* AppleIIISystemControl.h */,
-				008CB9A915E7B0AE00027B7B /* AppleIIIVideo.cpp */,
-				008CB9A815E7B0A900027B7B /* AppleIIIVideo.h */,
+				49EB4D2618C66FDD00AD682A /* DI2IMGBackingStore.cpp */,
+				49EB4D2718C66FDD00AD682A /* DI2IMGBackingStore.h */,
+				49EB4D2818C66FDD00AD682A /* DIApple35DiskStorage.cpp */,
+				49EB4D2918C66FDD00AD682A /* DIApple35DiskStorage.h */,
+				49EB4D2A18C66FDD00AD682A /* DIApple525DiskStorage.cpp */,
+				49EB4D2B18C66FDD00AD682A /* DIApple525DiskStorage.h */,
+				49EB4D2C18C66FDD00AD682A /* DIATABlockStorage.cpp */,
+				49EB4D2D18C66FDD00AD682A /* DIATABlockStorage.h */,
+				49EB4D2E18C66FDD00AD682A /* DIBackingStore.cpp */,
+				49EB4D2F18C66FDD00AD682A /* DIBackingStore.h */,
+				49EB4D3018C66FDD00AD682A /* DIBlockStorage.cpp */,
+				49EB4D3118C66FDD00AD682A /* DIBlockStorage.h */,
+				49EB4D3218C66FDD00AD682A /* DICommon.cpp */,
+				49EB4D3318C66FDD00AD682A /* DICommon.h */,
+				49EB4D3418C66FDD00AD682A /* DIDC42BackingStore.cpp */,
+				49EB4D3518C66FDD00AD682A /* DIDC42BackingStore.h */,
+				49EB4D3618C66FDD00AD682A /* DIDDLDiskStorage.cpp */,
+				49EB4D3718C66FDD00AD682A /* DIDDLDiskStorage.h */,
+				49EB4D3818C66FDD00AD682A /* DIDiskStorage.cpp */,
+				49EB4D3918C66FDD00AD682A /* DIDiskStorage.h */,
+				49EB4D3A18C66FDD00AD682A /* DIFDIDiskStorage.cpp */,
+				49EB4D3B18C66FDD00AD682A /* DIFDIDiskStorage.h */,
+				49EB4D3C18C66FDD00AD682A /* DIFileBackingStore.cpp */,
+				49EB4D3D18C66FDD00AD682A /* DIFileBackingStore.h */,
+				49EB4D3E18C66FDD00AD682A /* DILogicalDiskStorage.cpp */,
+				49EB4D3F18C66FDD00AD682A /* DILogicalDiskStorage.h */,
+				49EB4D4018C66FDD00AD682A /* DIRAMBackingStore.cpp */,
+				49EB4D4118C66FDD00AD682A /* DIRAMBackingStore.h */,
+				49EB4D4218C66FDD00AD682A /* DIRAWBlockStorage.cpp */,
+				49EB4D4318C66FDD00AD682A /* DIRAWBlockStorage.h */,
+				49EB4D4418C66FDD00AD682A /* diskimage.h */,
+				49EB4D4518C66FDD00AD682A /* DIV2DDiskStorage.cpp */,
+				49EB4D4618C66FDD00AD682A /* DIV2DDiskStorage.h */,
+				49EB4D4718C66FDD00AD682A /* DIVDIBlockStorage.cpp */,
+				49EB4D4818C66FDD00AD682A /* DIVDIBlockStorage.h */,
+				49EB4D4918C66FDD00AD682A /* DIVMDKBlockStorage.cpp */,
+				49EB4D4A18C66FDD00AD682A /* DIVMDKBlockStorage.h */,
 			);
-			path = Apple;
-			sourceTree = "<group>";
-		};
-		00B8882D12A393990052B7A4 /* Generic */ = {
-			isa = PBXGroup;
-			children = (
-				00B8882E12A393990052B7A4 /* AddressDecoder.cpp */,
-				00B8882F12A393990052B7A4 /* AddressDecoder.h */,
-				0029EEDF14266B7700AD900E /* AddressMapper.cpp */,
-				0029EEE114266B8000AD900E /* AddressMapper.h */,
-				00D7E40E158D1E4B00EBF8FA /* AddressMasker.cpp */,
-				00D7E40F158D1E4B00EBF8FA /* AddressMasker.h */,
-				00365CEA1516955C00978DF6 /* AddressMux.cpp */,
-				00365CEC1516956600978DF6 /* AddressMux.h */,
-				00B8883012A393990052B7A4 /* AddressOffset.cpp */,
-				00B8883112A393990052B7A4 /* AddressOffset.h */,
-				00839E44159705FC00BD4538 /* ATAController.cpp */,
-				00839E45159705FC00BD4538 /* ATAController.h */,
-				00EA1F0315976F0200079A54 /* ATADevice.cpp */,
-				00EA1F0415976F0200079A54 /* ATADevice.h */,
-				0084D43514FC4FF80031A8A5 /* Audio1Bit.cpp */,
-				0084D43714FC50060031A8A5 /* Audio1Bit.h */,
-				00B8883212A393990052B7A4 /* AudioCodec.cpp */,
-				00FBD2DD1419A03A00BA8CEE /* AudioCodec.h */,
-				00936E8715170435006B0EAC /* AudioPlayer.cpp */,
-				00936E8515170428006B0EAC /* AudioPlayer.h */,
-				00B8883812A393990052B7A4 /* ControlBus.cpp */,
-				00B8883912A393990052B7A4 /* ControlBus.h */,
-				00B8883A12A393990052B7A4 /* FloatingBus.cpp */,
-				00B8883B12A393990052B7A4 /* FloatingBus.h */,
-				00B7C645147B4B4100BB7E6B /* JoystickMapper.cpp */,
-				00B7C644147B4B2B00BB7E6B /* JoystickMapper.h */,
-				00B8883612A393990052B7A4 /* Monitor.cpp */,
-				00B8883712A393990052B7A4 /* Monitor.h */,
-				005316C61596D2C8007F3C86 /* Proxy.cpp */,
-				005316C41596D2BF007F3C86 /* Proxy.h */,
-				00B8883C12A393990052B7A4 /* RAM.cpp */,
-				00B8883D12A393990052B7A4 /* RAM.h */,
-				00B8883E12A393990052B7A4 /* ROM.cpp */,
-				00B8883F12A393990052B7A4 /* ROM.h */,
-				00092E5A156AA9D4007A9E04 /* VRAM.cpp */,
-				00092E5B156AA9D4007A9E04 /* VRAM.h */,
-			);
-			path = Generic;
-			sourceTree = "<group>";
-		};
-		00B8884212A393990052B7A4 /* MOS */ = {
-			isa = PBXGroup;
-			children = (
-				00B8884312A393990052B7A4 /* MOS6502.cpp */,
-				00B8884412A393990052B7A4 /* MOS6502.h */,
-				00B8884512A393990052B7A4 /* MOS6502IllegalOperations.h */,
-				00B8884612A393990052B7A4 /* MOS6502Opcodes.h */,
-				00B8884712A393990052B7A4 /* MOS6502Operations.h */,
-				00F2796E15B671E600E58F4F /* MOS6522.cpp */,
-				00F2797115B671EE00E58F4F /* MOS6522.h */,
-				00B8884C12A393990052B7A4 /* MOS6530.cpp */,
-				00B8884D12A393990052B7A4 /* MOS6530.h */,
-				007F6C3915CD06520004D4C4 /* MOS6551.cpp */,
-				007F6C3815CD064C0004D4C4 /* MOS6551.h */,
-				00B8884E12A393990052B7A4 /* MOSKIM1IO.cpp */,
-				00B8884F12A393990052B7A4 /* MOSKIM1IO.h */,
-				00B8885012A393990052B7A4 /* MOSKIM1PLL.cpp */,
-				00B8885112A393990052B7A4 /* MOSKIM1PLL.h */,
-			);
-			path = MOS;
-			sourceTree = "<group>";
-		};
-		00B8885212A393990052B7A4 /* Motorola */ = {
-			isa = PBXGroup;
-			children = (
-				00B8885312A393990052B7A4 /* MC6821.cpp */,
-				00B8885412A393990052B7A4 /* MC6821.h */,
-				00B8885512A393990052B7A4 /* MC6845.cpp */,
-				00B8885612A393990052B7A4 /* MC6845.h */,
-			);
-			path = Motorola;
-			sourceTree = "<group>";
-		};
-		00B8885712A393990052B7A4 /* Ricoh */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Ricoh;
-			sourceTree = "<group>";
-		};
-		00B8885D12A393990052B7A4 /* WDC */ = {
-			isa = PBXGroup;
-			children = (
-				004BD1BC1425AA8500768B80 /* W65C02S.cpp */,
-				004BD1BD1425AA8500768B80 /* W65C02S.h */,
-				004BD1BE1425AA8500768B80 /* W65C02SOpcodes.h */,
-				004BD1BF1425AA8500768B80 /* W65C02SOperations.h */,
-			);
-			path = WDC;
-			sourceTree = "<group>";
-		};
-		00B8886412A393990052B7A4 /* Zilog */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Zilog;
-			sourceTree = "<group>";
-		};
-		00B8886912A393990052B7A4 /* Interface */ = {
-			isa = PBXGroup;
-			children = (
-				00D225F91350F9A100FC69B9 /* Host */,
-				001CC97D13D11E9900B0DDA7 /* Generic */,
-				00B8886A12A393990052B7A4 /* Apple */,
-				00B8886C12A393990052B7A4 /* EIA */,
-				00B8887E12A393990052B7A4 /* IEEE */,
-			);
-			path = Interface;
-			sourceTree = "<group>";
-		};
-		00B8886A12A393990052B7A4 /* Apple */ = {
-			isa = PBXGroup;
-			children = (
-				00B8886B12A393990052B7A4 /* AppleIIInterface.h */,
-				003C0D5E15DB3BD200BCA5A4 /* AppleIIIInterface.h */,
-			);
-			path = Apple;
-			sourceTree = "<group>";
-		};
-		00B8886C12A393990052B7A4 /* EIA */ = {
-			isa = PBXGroup;
-			children = (
-				00B8886D12A393990052B7A4 /* RS232Interface.h */,
-			);
-			path = EIA;
-			sourceTree = "<group>";
-		};
-		00B8887E12A393990052B7A4 /* IEEE */ = {
-			isa = PBXGroup;
-			children = (
-				006A4C5B134ED2F30033BE4D /* IEEE488Interface.h */,
-				00B8887F12A393990052B7A4 /* IEEE1284Interface.h */,
-				00D73D9C136CC9B300BD5465 /* IEEE1394Interface.h */,
-			);
-			path = IEEE;
-			sourceTree = "<group>";
-		};
-		00CF206D15B0D8B400DA8E08 /* libutil */ = {
-			isa = PBXGroup;
-			children = (
-				00CF206F15B0D8C600DA8E08 /* util.cpp */,
-				00CF207015B0D8C600DA8E08 /* util.h */,
-			);
-			name = libutil;
-			sourceTree = "<group>";
-		};
-		00D225F91350F9A100FC69B9 /* Host */ = {
-			isa = PBXGroup;
-			children = (
-				00A90FB4150D3A0E00BB2999 /* AudioInterface.cpp */,
-				00D225FA1350F9A100FC69B9 /* AudioInterface.h */,
-				00D225FB1350F9A100FC69B9 /* CanvasInterface.h */,
-				00D225FD1350F9A100FC69B9 /* DeviceInterface.h */,
-				0042499615B8EA1C0091ECAB /* EmulationInterface.h */,
-				00D225FF1350F9A100FC69B9 /* EthernetInterface.h */,
-				001D1F7A1479E7BD0014D496 /* JoystickInterface.h */,
-				00D226001350F9A100FC69B9 /* MIDIInterface.h */,
-				000E8D1813515C6E00DBFB2C /* StorageInterface.h */,
-				00D226031350F9A100FC69B9 /* USBInterface.h */,
-				00D226041350F9A100FC69B9 /* VideoCaptureInterface.h */,
-			);
-			path = Host;
-			sourceTree = "<group>";
-		};
-		00E473201475689C00F367B7 /* libdiskimage */ = {
-			isa = PBXGroup;
-			children = (
-				00E473411475695500F367B7 /* diskimage.h */,
-				0020AE721530A22700E3DF80 /* DICommon.cpp */,
-				0020AE701530A21F00E3DF80 /* DICommon.h */,
-				007DEFB0153FB17500A9CC01 /* DIBackingStore.cpp */,
-				007DEFAA153FB0CB00A9CC01 /* DIBackingStore.h */,
-				00140DF5152D36F900D4795D /* DIFileBackingStore.cpp */,
-				00140DF7152D370300D4795D /* DIFileBackingStore.h */,
-				007DEFAE153FB16800A9CC01 /* DIRAMBackingStore.cpp */,
-				007DEFAC153FB15C00A9CC01 /* DIRAMBackingStore.h */,
-				00140DFB152D371C00D4795D /* DI2IMGBackingStore.cpp */,
-				00140DF9152D371000D4795D /* DI2IMGBackingStore.h */,
-				00140E0B152D37F400D4795D /* DIDC42BackingStore.cpp */,
-				00140E09152D37ED00D4795D /* DIDC42BackingStore.h */,
-				007DEFB2153FB5E800A9CC01 /* DIBlockStorage.cpp */,
-				007DEFB4153FB5EF00A9CC01 /* DIBlockStorage.h */,
-				007DEFBA1540608200A9CC01 /* DIRAWBlockStorage.cpp */,
-				007DEFB81540607C00A9CC01 /* DIRAWBlockStorage.h */,
-				0027E67D153738CC0066A9BE /* DIVDIBlockStorage.cpp */,
-				0027E67F153738D30066A9BE /* DIVDIBlockStorage.h */,
-				00536BC5153DD400005A5336 /* DIVMDKBlockStorage.cpp */,
-				00536BC4153DD3F5005A5336 /* DIVMDKBlockStorage.h */,
-				0019177D1543D320009A301E /* DIDiskStorage.cpp */,
-				0019177B1543D319009A301E /* DIDiskStorage.h */,
-				001917811543D346009A301E /* DILogicalDiskStorage.cpp */,
-				0019177F1543D337009A301E /* DILogicalDiskStorage.h */,
-				00B6A2DD15B1FC97005E7A5C /* DIDDLDiskStorage.cpp */,
-				00B6A2DE15B1FC97005E7A5C /* DIDDLDiskStorage.h */,
-				00140E03152D376400D4795D /* DIFDIDiskStorage.cpp */,
-				00140E01152D375D00D4795D /* DIFDIDiskStorage.h */,
-				00140E11152D395900D4795D /* DIV2DDiskStorage.cpp */,
-				00140E13152D396500D4795D /* DIV2DDiskStorage.h */,
-				00A06AE21533055600A494A7 /* DIATABlockStorage.cpp */,
-				00A06AE41533055D00A494A7 /* DIATABlockStorage.h */,
-				00140DEF152D282400D4795D /* DIApple525DiskStorage.cpp */,
-				00140DED152D281F00D4795D /* DIApple525DiskStorage.h */,
-				00A06AE81533EE3100A494A7 /* DIApple35DiskStorage.cpp */,
-				00A06AE61533EE2700A494A7 /* DIApple35DiskStorage.h */,
-			);
+			name = diskimage;
 			path = libdiskimage;
-			sourceTree = "<group>";
-		};
-		00EA1F07159799A100079A54 /* RD */ = {
-			isa = PBXGroup;
-			children = (
-				00EA1F08159799C400079A54 /* RDCFFA.cpp */,
-				00EA1F09159799C400079A54 /* RDCFFA.h */,
-			);
-			path = RD;
 			sourceTree = "<group>";
 		};
 		19C28FB0FE9D524F11CA2CBB /* Products */ = {
@@ -1261,104 +944,28 @@
 		2A37F4AAFDCFA73011CA2CEA /* OpenEmulator */ = {
 			isa = PBXGroup;
 			children = (
+				496AF1DF18C746F300B35159 /* roms */,
+				496AF1D718C677B600B35159 /* images */,
+				496AF1D818C677B600B35159 /* library */,
+				496AF1D918C677B600B35159 /* sounds */,
+				496AF1DA18C677B600B35159 /* templates */,
 				000A78A50FBA464600A0F12E /* OpenEmulator.app */,
-				00039E3C12B03BA90025D374 /* libemulation-hal */,
-				00B8864512A3923D0052B7A4 /* libemulation */,
-				00E473201475689C00F367B7 /* libdiskimage */,
-				00CF206D15B0D8B400DA8E08 /* libutil */,
+				00039E3C12B03BA90025D374 /* emulation-hal */,
+				00B8864512A3923D0052B7A4 /* emulation */,
+				00E473201475689C00F367B7 /* diskimage */,
+				00CF206D15B0D8B400DA8E08 /* util */,
 				001750AF13A50A690043E2ED /* Docs and Scripts */,
 				19C28FB0FE9D524F11CA2CBB /* Products */,
 			);
 			name = OpenEmulator;
 			sourceTree = "<group>";
 		};
-		2A37F4ABFDCFA73011CA2CEA /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				00D845730FFF0FD2005802F0 /* main.m */,
-				0014DF12148286A4006A7660 /* Application.h */,
-				0014DF13148286A5006A7660 /* Application.m */,
-				00D845760FFF0FD2005802F0 /* OpenEmulator_Prefix.pch */,
-				002579FB1218A83400206E56 /* NSStringAdditions.h */,
-				0009068D141D2A0300F06D99 /* NSStringAdditions.mm */,
-				00D845670FFF0FD2005802F0 /* DocumentController.h */,
-				00AD746811A2F10E00BAC29C /* DocumentController.mm */,
-				00B5709C10863C2A00CDE4A7 /* TemplateChooserWindowController.h */,
-				00B5709D10863C2A00CDE4A7 /* TemplateChooserWindowController.m */,
-				00FE0C041095353B00B92AB7 /* TemplateChooserViewController.h */,
-				00FE0C051095353B00B92AB7 /* TemplateChooserViewController.m */,
-				0071E3B810803F7300F2D54F /* TemplateChooserItem.h */,
-				0071E3B910803F7300F2D54F /* TemplateChooserItem.mm */,
-				00D845790FFF0FD2005802F0 /* PreferencesWindowController.h */,
-				00D8457A0FFF0FD2005802F0 /* PreferencesWindowController.m */,
-				00391CB112D3A320002C5ABD /* LibraryWindowController.h */,
-				00391CB212D3A320002C5ABD /* LibraryWindowController.m */,
-				004763D0139C94F30016277E /* LibraryTableView.h */,
-				004763D1139C94F30016277E /* LibraryTableView.m */,
-				0090853E1395D23D00B7D75F /* LibraryItem.h */,
-				0090853F1395D23D00B7D75F /* LibraryItem.mm */,
-				00D75C671399FFD7004AA153 /* LibraryTableCell.h */,
-				00D75C681399FFD9004AA153 /* LibraryTableCell.m */,
-				00954EA51277BC1200C17203 /* AudioControlsWindowController.h */,
-				00954EA61277BC1200C17203 /* AudioControlsWindowController.mm */,
-				00A0B7B81068949D007930A5 /* Document.h */,
-				00A0B8031069761A007930A5 /* Document.mm */,
-				00954E971277BB8E00C17203 /* EmulationWindowController.h */,
-				00954E981277BB8E00C17203 /* EmulationWindowController.m */,
-				00FE381912CA6790002B47B1 /* EmulationOutlineView.h */,
-				00FE381A12CA6790002B47B1 /* EmulationOutlineView.m */,
-				00BB34B212C5C5AE007332B5 /* EmulationItem.h */,
-				00BB34B312C5C5AE007332B5 /* EmulationItem.mm */,
-				00954E761277B79E00C17203 /* EmulationOutlineCell.h */,
-				00954E771277B79E00C17203 /* EmulationOutlineCell.m */,
-				00A72B6912879F530083C6A7 /* CanvasWindowController.h */,
-				00A72B6A12879F530083C6A7 /* CanvasWindowController.m */,
-				00A72B7112879F800083C6A7 /* CanvasWindow.h */,
-				00A72B7212879F800083C6A7 /* CanvasWindow.m */,
-				00A72B6D12879F650083C6A7 /* CanvasView.h */,
-				00A72B6E12879F650083C6A7 /* CanvasView.mm */,
-				0073DD8D136FCA1C00087303 /* CanvasToolbarView.h */,
-				0073DD8E136FCA1C00087303 /* CanvasToolbarView.m */,
-				00BDB1F513863188004DF2AF /* CanvasPrintView.h */,
-				00BDB1F613863188004DF2AF /* CanvasPrintView.m */,
-				0040284012B44878001C2F73 /* BackgroundView.h */,
-				0040284112B44878001C2F73 /* BackgroundView.m */,
-				00F21CE512C7C7EE00A809EF /* VerticallyCenteredTextFieldCell.h */,
-				00F21CE612C7C7EE00A809EF /* VerticallyCenteredTextFieldCell.m */,
-			);
-			name = Sources;
-			path = macosx;
-			sourceTree = "<group>";
-		};
-		2A37F4B8FDCFA73011CA2CEA /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				00D844BD0FFF0505005802F0 /* MainMenu.xib */,
-				00679D06100817F700B38748 /* TemplateChooser.xib */,
-				00391F6A12D3FFF3002C5ABD /* TemplateChooserView.xib */,
-				00D844C30FFF0505005802F0 /* Preferences.xib */,
-				00391D6212D3B588002C5ABD /* Library.xib */,
-				0078F653127348ED0042577E /* AudioControls.xib */,
-				00CAD7D712A04C22002B92E5 /* Emulation.xib */,
-				00A72B931287A0F10083C6A7 /* Canvas.xib */,
-				0008FCD80FBA5D72005E876E /* Info.plist */,
-				007F08CE1459344600C3308D /* sparkle_dsa_pub.pem */,
-				000A79070FBA49C500A0F12E /* Images */,
-				003E2597107075D900185260 /* images */,
-				00391D9912D3B94F002C5ABD /* library */,
-				00B974AD10701DCD00BD1402 /* sounds */,
-				00C6C08810602151004D084B /* roms */,
-				005928540FFC94E200F24A57 /* templates */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-		};
 		2A37F4C3FDCFA73011CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				002F57F515CDF6DF00C19659 /* libFLAC.a */,
+				49EB4D1318C65CD500AD682A /* libpng16.a */,
+				49EB4C4218C63B1800AD682A /* libFLAC.dylib */,
 				002F57F315CDF66B00C19659 /* libogg.a */,
-				002F57F115CDF4D100C19659 /* libpng14.a */,
 				002F57EF15CDF4CB00C19659 /* libportaudio.a */,
 				002F57ED15CDF4C600C19659 /* libsamplerate.a */,
 				002F57EB15CDF4C000C19659 /* libsndfile.a */,
@@ -1378,9 +985,434 @@
 				008CA97D147803E500B9F5D0 /* IOKit.framework */,
 				0054E4A61131BE8A006D32D9 /* OpenGL.framework */,
 				0054E66B1131BF58006D32D9 /* Quartz.framework */,
-				001F56F80FD1E8E500EA246A /* Sparkle.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		49EB4C4818C63BE500AD682A /* src */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4C4918C63BE500AD682A /* macosx */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		49EB4C4918C63BE500AD682A /* macosx */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4C4A18C63BE500AD682A /* Application.h */,
+				49EB4C4B18C63BE500AD682A /* Application.m */,
+				49EB4C4C18C63BE500AD682A /* AudioControlsWindowController.h */,
+				49EB4C4D18C63BE500AD682A /* AudioControlsWindowController.mm */,
+				49EB4C4E18C63BE500AD682A /* BackgroundView.h */,
+				49EB4C4F18C63BE500AD682A /* BackgroundView.m */,
+				49EB4C5018C63BE500AD682A /* CanvasPrintView.h */,
+				49EB4C5118C63BE500AD682A /* CanvasPrintView.m */,
+				49EB4C5218C63BE500AD682A /* CanvasToolbarView.h */,
+				49EB4C5318C63BE500AD682A /* CanvasToolbarView.m */,
+				49EB4C5418C63BE500AD682A /* CanvasView.h */,
+				49EB4C5518C63BE500AD682A /* CanvasView.mm */,
+				49EB4C5618C63BE500AD682A /* CanvasWindow.h */,
+				49EB4C5718C63BE500AD682A /* CanvasWindow.m */,
+				49EB4C5818C63BE500AD682A /* CanvasWindowController.h */,
+				49EB4C5918C63BE500AD682A /* CanvasWindowController.m */,
+				49EB4C5A18C63BE500AD682A /* Document.h */,
+				49EB4C5B18C63BE500AD682A /* Document.mm */,
+				49EB4C5C18C63BE500AD682A /* DocumentController.h */,
+				49EB4C5D18C63BE500AD682A /* DocumentController.mm */,
+				49EB4C5E18C63BE500AD682A /* EmulationItem.h */,
+				49EB4C5F18C63BE500AD682A /* EmulationItem.mm */,
+				49EB4C6018C63BE500AD682A /* EmulationOutlineCell.h */,
+				49EB4C6118C63BE500AD682A /* EmulationOutlineCell.m */,
+				49EB4C6218C63BE500AD682A /* EmulationOutlineView.h */,
+				49EB4C6318C63BE500AD682A /* EmulationOutlineView.m */,
+				49EB4C6418C63BE500AD682A /* EmulationWindowController.h */,
+				49EB4C6518C63BE500AD682A /* EmulationWindowController.m */,
+				49EB4C6618C63BE500AD682A /* AudioControls.xib */,
+				49EB4C6818C63BE500AD682A /* Canvas.xib */,
+				49EB4C6A18C63BE500AD682A /* Emulation.xib */,
+				49EB4C6C18C63BE500AD682A /* Library.xib */,
+				49EB4C6E18C63BE500AD682A /* MainMenu.xib */,
+				49EB4C7018C63BE500AD682A /* Preferences.xib */,
+				49EB4C7218C63BE500AD682A /* TemplateChooser.xib */,
+				49EB4C7418C63BE500AD682A /* TemplateChooserView.xib */,
+				49EB4C7618C63BE500AD682A /* Images */,
+				49EB4C9618C63BE500AD682A /* Info.plist */,
+				49EB4C9718C63BE500AD682A /* LibraryItem.h */,
+				49EB4C9818C63BE500AD682A /* LibraryItem.mm */,
+				49EB4C9918C63BE500AD682A /* LibraryTableCell.h */,
+				49EB4C9A18C63BE500AD682A /* LibraryTableCell.m */,
+				49EB4C9B18C63BE500AD682A /* LibraryTableView.h */,
+				49EB4C9C18C63BE500AD682A /* LibraryTableView.m */,
+				49EB4C9D18C63BE500AD682A /* LibraryWindowController.h */,
+				49EB4C9E18C63BE500AD682A /* LibraryWindowController.m */,
+				49EB4C9F18C63BE500AD682A /* main.m */,
+				49EB4CA018C63BE500AD682A /* NSStringAdditions.h */,
+				49EB4CA118C63BE500AD682A /* NSStringAdditions.mm */,
+				49EB4CA218C63BE500AD682A /* OpenEmulator_Prefix.pch */,
+				49EB4CA318C63BE500AD682A /* PreferencesWindowController.h */,
+				49EB4CA418C63BE500AD682A /* PreferencesWindowController.m */,
+				49EB4CA618C63BE500AD682A /* sparkle_dsa_pub.pem */,
+				49EB4CA718C63BE500AD682A /* TemplateChooserItem.h */,
+				49EB4CA818C63BE500AD682A /* TemplateChooserItem.mm */,
+				49EB4CA918C63BE500AD682A /* TemplateChooserViewController.h */,
+				49EB4CAA18C63BE500AD682A /* TemplateChooserViewController.m */,
+				49EB4CAB18C63BE500AD682A /* TemplateChooserWindowController.h */,
+				49EB4CAC18C63BE500AD682A /* TemplateChooserWindowController.m */,
+				49EB4CAD18C63BE500AD682A /* VerticallyCenteredTextFieldCell.h */,
+				49EB4CAE18C63BE500AD682A /* VerticallyCenteredTextFieldCell.m */,
+				49EB4CF618C6536000AD682A /* English.lproj */,
+			);
+			path = macosx;
+			sourceTree = "<group>";
+		};
+		49EB4C7618C63BE500AD682A /* Images */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4C7718C63BE500AD682A /* AudioMax.png */,
+				49EB4C7818C63BE500AD682A /* AudioMin.png */,
+				49EB4C7918C63BE500AD682A /* AudioPause.png */,
+				49EB4C7A18C63BE500AD682A /* AudioPlay.png */,
+				49EB4C7B18C63BE500AD682A /* AudioRecord.png */,
+				49EB4C7C18C63BE500AD682A /* AudioStop.png */,
+				49EB4C7D18C63BE500AD682A /* DiskImage.icns */,
+				49EB4C7E18C63BE500AD682A /* Emulation.icns */,
+				49EB4C7F18C63BE500AD682A /* EmulationShow.png */,
+				49EB4C8018C63BE500AD682A /* EmulationShowPressed.png */,
+				49EB4C8118C63BE500AD682A /* EmulationShowRollover.png */,
+				49EB4C8218C63BE500AD682A /* EmulationShowSelected.png */,
+				49EB4C8318C63BE500AD682A /* EmulationUnmount.png */,
+				49EB4C8418C63BE500AD682A /* EmulationUnmountPressed.png */,
+				49EB4C8518C63BE500AD682A /* EmulationUnmountRollover.png */,
+				49EB4C8618C63BE500AD682A /* EmulationUnmountSelected.png */,
+				49EB4C8718C63BE500AD682A /* IconAudio.png */,
+				49EB4C8818C63BE500AD682A /* IconColdRestart.png */,
+				49EB4C8918C63BE500AD682A /* IconDebuggerBreak.png */,
+				49EB4C8A18C63BE500AD682A /* IconDevices.png */,
+				49EB4C8B18C63BE500AD682A /* IconGeneral.png */,
+				49EB4C8C18C63BE500AD682A /* IconInspector.png */,
+				49EB4C8D18C63BE500AD682A /* IconLibrary.png */,
+				49EB4C8E18C63BE500AD682A /* IconPowerDown.png */,
+				49EB4C8F18C63BE500AD682A /* IconRevert.png */,
+				49EB4C9018C63BE500AD682A /* IconSleep.png */,
+				49EB4C9118C63BE500AD682A /* IconVideo.png */,
+				49EB4C9218C63BE500AD682A /* IconWakeUp.png */,
+				49EB4C9318C63BE500AD682A /* IconWarmRestart.png */,
+				49EB4C9418C63BE500AD682A /* OpenEmulator.icns */,
+				49EB4C9518C63BE500AD682A /* ToolbarBackground.png */,
+			);
+			path = Images;
+			sourceTree = "<group>";
+		};
+		49EB4CF618C6536000AD682A /* English.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4CF718C6536000AD682A /* AudioControls.xib */,
+				49EB4CF918C6536000AD682A /* Canvas.xib */,
+				49EB4CFB18C6536000AD682A /* Emulation.xib */,
+				49EB4CFD18C6536000AD682A /* Library.xib */,
+				49EB4CFF18C6536000AD682A /* MainMenu.xib */,
+				49EB4D0118C6536000AD682A /* Preferences.xib */,
+				49EB4D0318C6536100AD682A /* TemplateChooser.xib */,
+				49EB4D0518C6536100AD682A /* TemplateChooserView.xib */,
+			);
+			path = English.lproj;
+			sourceTree = "<group>";
+		};
+		49EB4D7018C6702100AD682A /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4D7118C6702100AD682A /* OECommon.cpp */,
+				49EB4D7218C6702100AD682A /* OECommon.h */,
+				49EB4D7318C6702100AD682A /* OEComponent.cpp */,
+				49EB4D7418C6702100AD682A /* OEComponent.h */,
+				49EB4D7518C6702100AD682A /* OEComponentFactory.cpp */,
+				49EB4D7618C6702100AD682A /* OEComponentFactory.h */,
+				49EB4D7718C6702100AD682A /* OEDevice.cpp */,
+				49EB4D7818C6702100AD682A /* OEDevice.h */,
+				49EB4D7918C6702100AD682A /* OEDocument.cpp */,
+				49EB4D7A18C6702100AD682A /* OEDocument.h */,
+				49EB4D7B18C6702100AD682A /* OEEmulation.cpp */,
+				49EB4D7C18C6702100AD682A /* OEEmulation.h */,
+				49EB4D7D18C6702100AD682A /* OEImage.cpp */,
+				49EB4D7E18C6702100AD682A /* OEImage.h */,
+				49EB4D7F18C6702100AD682A /* OEPackage.cpp */,
+				49EB4D8018C6702100AD682A /* OEPackage.h */,
+				49EB4D8118C6702100AD682A /* OESound.cpp */,
+				49EB4D8218C6702100AD682A /* OESound.h */,
+			);
+			name = Core;
+			path = lib/libemulation/Core;
+			sourceTree = SOURCE_ROOT;
+		};
+		49EB4D8518C6702100AD682A /* Implementation */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4D8618C6702100AD682A /* Apple */,
+				49EB4DC318C6702100AD682A /* Generic */,
+				49EB4DE818C6702200AD682A /* MOS */,
+				49EB4DFC18C6702200AD682A /* Motorola */,
+				49EB4E0118C6702200AD682A /* National */,
+				49EB4E0418C6702200AD682A /* RD */,
+				49EB4E0D18C6702200AD682A /* Videx */,
+				49EB4E1018C6702200AD682A /* WDC */,
+			);
+			name = Implementation;
+			path = lib/libemulation/Implementation;
+			sourceTree = SOURCE_ROOT;
+		};
+		49EB4D8618C6702100AD682A /* Apple */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4D8718C6702100AD682A /* Apple1ACI.cpp */,
+				49EB4D8818C6702100AD682A /* Apple1ACI.h */,
+				49EB4D8918C6702100AD682A /* Apple1IO.cpp */,
+				49EB4D8A18C6702100AD682A /* Apple1IO.h */,
+				49EB4D8B18C6702100AD682A /* Apple1Terminal.cpp */,
+				49EB4D8C18C6702100AD682A /* Apple1Terminal.h */,
+				49EB4D8D18C6702100AD682A /* AppleDiskDrive525.cpp */,
+				49EB4D8E18C6702100AD682A /* AppleDiskDrive525.h */,
+				49EB4D8F18C6702100AD682A /* AppleDiskIIInterfaceCard.cpp */,
+				49EB4D9018C6702100AD682A /* AppleDiskIIInterfaceCard.h */,
+				49EB4D9118C6702100AD682A /* AppleGraphicsTablet.cpp */,
+				49EB4D9218C6702100AD682A /* AppleGraphicsTablet.h */,
+				49EB4D9318C6702100AD682A /* AppleGraphicsTabletInterfaceCard.cpp */,
+				49EB4D9418C6702100AD682A /* AppleGraphicsTabletInterfaceCard.h */,
+				49EB4D9518C6702100AD682A /* AppleIIAddressDecoder.cpp */,
+				49EB4D9618C6702100AD682A /* AppleIIAddressDecoder.h */,
+				49EB4D9718C6702100AD682A /* AppleIIAudioIn.cpp */,
+				49EB4D9818C6702100AD682A /* AppleIIAudioIn.h */,
+				49EB4D9918C6702100AD682A /* AppleIIAudioOut.cpp */,
+				49EB4D9A18C6702100AD682A /* AppleIIAudioOut.h */,
+				49EB4D9B18C6702100AD682A /* AppleIIDisableC800.cpp */,
+				49EB4D9C18C6702100AD682A /* AppleIIDisableC800.h */,
+				49EB4D9D18C6702100AD682A /* AppleIIFloatingBus.cpp */,
+				49EB4D9E18C6702100AD682A /* AppleIIFloatingBus.h */,
+				49EB4D9F18C6702100AD682A /* AppleIIGamePort.cpp */,
+				49EB4DA018C6702100AD682A /* AppleIIGamePort.h */,
+				49EB4DA118C6702100AD682A /* AppleIIIAddressDecoder.cpp */,
+				49EB4DA218C6702100AD682A /* AppleIIIAddressDecoder.h */,
+				49EB4DA318C6702100AD682A /* AppleIIIBeeper.cpp */,
+				49EB4DA418C6702100AD682A /* AppleIIIBeeper.h */,
+				49EB4DA518C6702100AD682A /* AppleIIIDiskIO.cpp */,
+				49EB4DA618C6702100AD682A /* AppleIIIDiskIO.h */,
+				49EB4DA718C6702100AD682A /* AppleIIIGamePort.cpp */,
+				49EB4DA818C6702100AD682A /* AppleIIIGamePort.h */,
+				49EB4DA918C6702100AD682A /* AppleIIIKeyboard.cpp */,
+				49EB4DAA18C6702100AD682A /* AppleIIIKeyboard.h */,
+				49EB4DAB18C6702100AD682A /* AppleIIIMOS6502.cpp */,
+				49EB4DAC18C6702100AD682A /* AppleIIIMOS6502.h */,
+				49EB4DAD18C6702100AD682A /* AppleIIIMOS6502Opcodes.h */,
+				49EB4DAE18C6702100AD682A /* AppleIIIMOS6502Operations.h */,
+				49EB4DAF18C6702100AD682A /* AppleIIIRTC.cpp */,
+				49EB4DB018C6702100AD682A /* AppleIIIRTC.h */,
+				49EB4DB118C6702100AD682A /* AppleIIISystemControl.cpp */,
+				49EB4DB218C6702100AD682A /* AppleIIISystemControl.h */,
+				49EB4DB318C6702100AD682A /* AppleIIIVideo.cpp */,
+				49EB4DB418C6702100AD682A /* AppleIIIVideo.h */,
+				49EB4DB518C6702100AD682A /* AppleIIKeyboard.cpp */,
+				49EB4DB618C6702100AD682A /* AppleIIKeyboard.h */,
+				49EB4DB718C6702100AD682A /* AppleIISlotController.cpp */,
+				49EB4DB818C6702100AD682A /* AppleIISlotController.h */,
+				49EB4DB918C6702100AD682A /* AppleIISystemControl.cpp */,
+				49EB4DBA18C6702100AD682A /* AppleIISystemControl.h */,
+				49EB4DBB18C6702100AD682A /* AppleIIVideo.cpp */,
+				49EB4DBC18C6702100AD682A /* AppleIIVideo.h */,
+				49EB4DBD18C6702100AD682A /* AppleLanguageCard.cpp */,
+				49EB4DBE18C6702100AD682A /* AppleLanguageCard.h */,
+				49EB4DBF18C6702100AD682A /* AppleSilentype.cpp */,
+				49EB4DC018C6702100AD682A /* AppleSilentype.h */,
+				49EB4DC118C6702100AD682A /* AppleSilentypeInterfaceCard.cpp */,
+				49EB4DC218C6702100AD682A /* AppleSilentypeInterfaceCard.h */,
+			);
+			path = Apple;
+			sourceTree = "<group>";
+		};
+		49EB4DC318C6702100AD682A /* Generic */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4DC418C6702100AD682A /* AddressDecoder.cpp */,
+				49EB4DC518C6702100AD682A /* AddressDecoder.h */,
+				49EB4DC618C6702100AD682A /* AddressMapper.cpp */,
+				49EB4DC718C6702100AD682A /* AddressMapper.h */,
+				49EB4DC818C6702100AD682A /* AddressMasker.cpp */,
+				49EB4DC918C6702100AD682A /* AddressMasker.h */,
+				49EB4DCA18C6702100AD682A /* AddressMux.cpp */,
+				49EB4DCB18C6702100AD682A /* AddressMux.h */,
+				49EB4DCC18C6702100AD682A /* AddressOffset.cpp */,
+				49EB4DCD18C6702100AD682A /* AddressOffset.h */,
+				49EB4DCE18C6702100AD682A /* ATAController.cpp */,
+				49EB4DCF18C6702100AD682A /* ATAController.h */,
+				49EB4DD018C6702200AD682A /* ATADevice.cpp */,
+				49EB4DD118C6702200AD682A /* ATADevice.h */,
+				49EB4DD218C6702200AD682A /* Audio1Bit.cpp */,
+				49EB4DD318C6702200AD682A /* Audio1Bit.h */,
+				49EB4DD418C6702200AD682A /* AudioCodec.cpp */,
+				49EB4DD518C6702200AD682A /* AudioCodec.h */,
+				49EB4DD618C6702200AD682A /* AudioPlayer.cpp */,
+				49EB4DD718C6702200AD682A /* AudioPlayer.h */,
+				49EB4DD818C6702200AD682A /* ControlBus.cpp */,
+				49EB4DD918C6702200AD682A /* ControlBus.h */,
+				49EB4DDA18C6702200AD682A /* FloatingBus.cpp */,
+				49EB4DDB18C6702200AD682A /* FloatingBus.h */,
+				49EB4DDC18C6702200AD682A /* JoystickMapper.cpp */,
+				49EB4DDD18C6702200AD682A /* JoystickMapper.h */,
+				49EB4DDE18C6702200AD682A /* Monitor.cpp */,
+				49EB4DDF18C6702200AD682A /* Monitor.h */,
+				49EB4DE018C6702200AD682A /* Proxy.cpp */,
+				49EB4DE118C6702200AD682A /* Proxy.h */,
+				49EB4DE218C6702200AD682A /* RAM.cpp */,
+				49EB4DE318C6702200AD682A /* RAM.h */,
+				49EB4DE418C6702200AD682A /* ROM.cpp */,
+				49EB4DE518C6702200AD682A /* ROM.h */,
+				49EB4DE618C6702200AD682A /* VRAM.cpp */,
+				49EB4DE718C6702200AD682A /* VRAM.h */,
+			);
+			path = Generic;
+			sourceTree = "<group>";
+		};
+		49EB4DE818C6702200AD682A /* MOS */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4DE918C6702200AD682A /* MOS6502.cpp */,
+				49EB4DEA18C6702200AD682A /* MOS6502.h */,
+				49EB4DEB18C6702200AD682A /* MOS6502IllegalOperations.h */,
+				49EB4DEC18C6702200AD682A /* MOS6502Opcodes.h */,
+				49EB4DED18C6702200AD682A /* MOS6502Operations.h */,
+				49EB4DF218C6702200AD682A /* MOS6522.cpp */,
+				49EB4DF318C6702200AD682A /* MOS6522.h */,
+				49EB4DF418C6702200AD682A /* MOS6530.cpp */,
+				49EB4DF518C6702200AD682A /* MOS6530.h */,
+				49EB4DF618C6702200AD682A /* MOS6551.cpp */,
+				49EB4DF718C6702200AD682A /* MOS6551.h */,
+				49EB4DF818C6702200AD682A /* MOSKIM1IO.cpp */,
+				49EB4DF918C6702200AD682A /* MOSKIM1IO.h */,
+				49EB4DFA18C6702200AD682A /* MOSKIM1PLL.cpp */,
+				49EB4DFB18C6702200AD682A /* MOSKIM1PLL.h */,
+			);
+			path = MOS;
+			sourceTree = "<group>";
+		};
+		49EB4DFC18C6702200AD682A /* Motorola */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4DFD18C6702200AD682A /* MC6821.cpp */,
+				49EB4DFE18C6702200AD682A /* MC6821.h */,
+				49EB4DFF18C6702200AD682A /* MC6845.cpp */,
+				49EB4E0018C6702200AD682A /* MC6845.h */,
+			);
+			path = Motorola;
+			sourceTree = "<group>";
+		};
+		49EB4E0118C6702200AD682A /* National */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E0218C6702200AD682A /* MM58167.cpp */,
+				49EB4E0318C6702200AD682A /* MM58167.h */,
+			);
+			path = National;
+			sourceTree = "<group>";
+		};
+		49EB4E0418C6702200AD682A /* RD */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E0518C6702200AD682A /* RDCFFA.cpp */,
+				49EB4E0618C6702200AD682A /* RDCFFA.h */,
+			);
+			path = RD;
+			sourceTree = "<group>";
+		};
+		49EB4E0D18C6702200AD682A /* Videx */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E0E18C6702200AD682A /* VidexVideoterm.cpp */,
+				49EB4E0F18C6702200AD682A /* VidexVideoterm.h */,
+			);
+			path = Videx;
+			sourceTree = "<group>";
+		};
+		49EB4E1018C6702200AD682A /* WDC */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E1118C6702200AD682A /* W65C02S.cpp */,
+				49EB4E1218C6702200AD682A /* W65C02S.h */,
+				49EB4E1318C6702200AD682A /* W65C02SOpcodes.h */,
+				49EB4E1418C6702200AD682A /* W65C02SOperations.h */,
+				49EB4E1518C6702200AD682A /* W65C816S.cpp */,
+				49EB4E1618C6702200AD682A /* W65C816S.h */,
+			);
+			path = WDC;
+			sourceTree = "<group>";
+		};
+		49EB4E1C18C6702200AD682A /* Interface */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E1D18C6702200AD682A /* Apple */,
+				49EB4E2018C6702200AD682A /* EIA */,
+				49EB4E2218C6702200AD682A /* Generic */,
+				49EB4E2918C6702200AD682A /* Host */,
+				49EB4E3518C6702200AD682A /* IEEE */,
+			);
+			name = Interface;
+			path = lib/libemulation/Interface;
+			sourceTree = SOURCE_ROOT;
+		};
+		49EB4E1D18C6702200AD682A /* Apple */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E1E18C6702200AD682A /* AppleIIIInterface.h */,
+				49EB4E1F18C6702200AD682A /* AppleIIInterface.h */,
+			);
+			path = Apple;
+			sourceTree = "<group>";
+		};
+		49EB4E2018C6702200AD682A /* EIA */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E2118C6702200AD682A /* RS232Interface.h */,
+			);
+			path = EIA;
+			sourceTree = "<group>";
+		};
+		49EB4E2218C6702200AD682A /* Generic */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E2318C6702200AD682A /* AudioPlayerInterface.h */,
+				49EB4E2418C6702200AD682A /* ControlBusInterface.h */,
+				49EB4E2518C6702200AD682A /* CPUInterface.h */,
+				49EB4E2618C6702200AD682A /* MemoryInterface.cpp */,
+				49EB4E2718C6702200AD682A /* MemoryInterface.h */,
+				49EB4E2818C6702200AD682A /* PIAInterface.h */,
+			);
+			path = Generic;
+			sourceTree = "<group>";
+		};
+		49EB4E2918C6702200AD682A /* Host */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E2A18C6702200AD682A /* AudioInterface.cpp */,
+				49EB4E2B18C6702200AD682A /* AudioInterface.h */,
+				49EB4E2C18C6702200AD682A /* CanvasInterface.h */,
+				49EB4E2D18C6702200AD682A /* DeviceInterface.h */,
+				49EB4E2E18C6702200AD682A /* EmulationInterface.h */,
+				49EB4E2F18C6702200AD682A /* EthernetInterface.h */,
+				49EB4E3018C6702200AD682A /* JoystickInterface.h */,
+				49EB4E3118C6702200AD682A /* MIDIInterface.h */,
+				49EB4E3218C6702200AD682A /* StorageInterface.h */,
+				49EB4E3318C6702200AD682A /* USBInterface.h */,
+				49EB4E3418C6702200AD682A /* VideoCaptureInterface.h */,
+			);
+			path = Host;
+			sourceTree = "<group>";
+		};
+		49EB4E3518C6702200AD682A /* IEEE */ = {
+			isa = PBXGroup;
+			children = (
+				49EB4E3618C6702200AD682A /* IEEE1284Interface.h */,
+				49EB4E3718C6702200AD682A /* IEEE1394Interface.h */,
+				49EB4E3818C6702200AD682A /* IEEE488Interface.h */,
+			);
+			path = IEEE;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1390,11 +1422,11 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00AB96A0157FA02F00EDACD5 /* OpenGLCanvas.h in Headers */,
-				00AB96A1157FA02F00EDACD5 /* PAAudio.h in Headers */,
-				00AB96A2157FA02F00EDACD5 /* OEVector.h in Headers */,
-				00AB96A3157FA02F00EDACD5 /* OEMatrix3.h in Headers */,
-				00AB96A4157FA02F00EDACD5 /* HIDJoystick.h in Headers */,
+				49EB4F0118C6709F00AD682A /* PAAudio.h in Headers */,
+				49EB4EF918C6709F00AD682A /* HIDJoystick.h in Headers */,
+				49EB4EFF18C6709F00AD682A /* OpenGLCanvas.h in Headers */,
+				49EB4EFD18C6709F00AD682A /* OEVector.h in Headers */,
+				49EB4EFB18C6709F00AD682A /* OEMatrix3.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1402,25 +1434,25 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00AB967F157F9F1800EDACD5 /* diskimage.h in Headers */,
-				00AB9680157F9F1800EDACD5 /* DICommon.h in Headers */,
-				00AB9681157F9F1800EDACD5 /* DIBackingStore.h in Headers */,
-				00AB9682157F9F1800EDACD5 /* DIFileBackingStore.h in Headers */,
-				00AB9683157F9F1800EDACD5 /* DIRAMBackingStore.h in Headers */,
-				00AB9684157F9F1800EDACD5 /* DI2IMGBackingStore.h in Headers */,
-				00AB9685157F9F1800EDACD5 /* DIDC42BackingStore.h in Headers */,
-				00AB9686157F9F1800EDACD5 /* DIBlockStorage.h in Headers */,
-				00AB9687157F9F1800EDACD5 /* DIRAWBlockStorage.h in Headers */,
-				00AB9688157F9F1800EDACD5 /* DIVDIBlockStorage.h in Headers */,
-				00AB9689157F9F1800EDACD5 /* DIVMDKBlockStorage.h in Headers */,
-				00AB968A157F9F1800EDACD5 /* DIDiskStorage.h in Headers */,
-				00AB968B157F9F1800EDACD5 /* DILogicalDiskStorage.h in Headers */,
-				00AB968C157F9F1800EDACD5 /* DIFDIDiskStorage.h in Headers */,
-				00AB968D157F9F1800EDACD5 /* DIV2DDiskStorage.h in Headers */,
-				00AB968E157F9F1800EDACD5 /* DIATABlockStorage.h in Headers */,
-				00AB968F157F9F1800EDACD5 /* DIApple525DiskStorage.h in Headers */,
-				00AB9690157F9F1800EDACD5 /* DIApple35DiskStorage.h in Headers */,
-				00B6A2E015B1FC97005E7A5C /* DIDDLDiskStorage.h in Headers */,
+				49EB4D5A18C66FDD00AD682A /* DIDC42BackingStore.h in Headers */,
+				49EB4D6F18C66FDD00AD682A /* DIVMDKBlockStorage.h in Headers */,
+				49EB4D5818C66FDD00AD682A /* DICommon.h in Headers */,
+				49EB4D6B18C66FDD00AD682A /* DIV2DDiskStorage.h in Headers */,
+				49EB4D5E18C66FDD00AD682A /* DIDiskStorage.h in Headers */,
+				49EB4D5218C66FDD00AD682A /* DIATABlockStorage.h in Headers */,
+				49EB4D6D18C66FDD00AD682A /* DIVDIBlockStorage.h in Headers */,
+				49EB4D6618C66FDD00AD682A /* DIRAMBackingStore.h in Headers */,
+				49EB4D5618C66FDD00AD682A /* DIBlockStorage.h in Headers */,
+				49EB4D5418C66FDD00AD682A /* DIBackingStore.h in Headers */,
+				49EB4D6418C66FDD00AD682A /* DILogicalDiskStorage.h in Headers */,
+				49EB4D5018C66FDD00AD682A /* DIApple525DiskStorage.h in Headers */,
+				49EB4D5C18C66FDD00AD682A /* DIDDLDiskStorage.h in Headers */,
+				49EB4D6018C66FDD00AD682A /* DIFDIDiskStorage.h in Headers */,
+				49EB4D4C18C66FDD00AD682A /* DI2IMGBackingStore.h in Headers */,
+				49EB4D4E18C66FDD00AD682A /* DIApple35DiskStorage.h in Headers */,
+				49EB4D6818C66FDD00AD682A /* DIRAWBlockStorage.h in Headers */,
+				49EB4D6218C66FDD00AD682A /* DIFileBackingStore.h in Headers */,
+				49EB4D6918C66FDD00AD682A /* diskimage.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1428,88 +1460,103 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00092E5D156AA9D4007A9E04 /* VRAM.h in Headers */,
-				00379133157B285F0020138F /* AppleGraphicsTabletInterfaceCard.h in Headers */,
-				00AB963F157F9EBE00EDACD5 /* Apple1ACI.h in Headers */,
-				00AB9640157F9EBE00EDACD5 /* Apple1IO.h in Headers */,
-				00AB9641157F9EBE00EDACD5 /* Apple1Terminal.h in Headers */,
-				00AB9642157F9EBE00EDACD5 /* AppleDiskDrive525.h in Headers */,
-				00AB9643157F9EBE00EDACD5 /* AppleDiskIIInterfaceCard.h in Headers */,
-				00AB9644157F9EBE00EDACD5 /* AppleGraphicsTablet.h in Headers */,
-				00AB9645157F9EBE00EDACD5 /* AppleLanguageCard.h in Headers */,
-				00AB9646157F9EBE00EDACD5 /* AppleIIAddressDecoder.h in Headers */,
-				00AB9647157F9EBE00EDACD5 /* AppleIIAudioIn.h in Headers */,
-				00AB9648157F9EBE00EDACD5 /* AppleIIAudioOut.h in Headers */,
-				00AB9649157F9EBE00EDACD5 /* AppleIIFloatingBus.h in Headers */,
-				00AB964A157F9EBE00EDACD5 /* AppleIIGamePort.h in Headers */,
-				00AB964B157F9EBE00EDACD5 /* AppleIIKeyboard.h in Headers */,
-				00AB964C157F9EBE00EDACD5 /* AppleIISlotController.h in Headers */,
-				00AB964D157F9EBE00EDACD5 /* AppleIIVideo.h in Headers */,
-				00AB964E157F9EBE00EDACD5 /* AppleSilentype.h in Headers */,
-				00AB964F157F9EBE00EDACD5 /* AppleSilentypeInterfaceCard.h in Headers */,
-				00AB9650157F9EC700EDACD5 /* AddressDecoder.h in Headers */,
-				00AB9651157F9EC700EDACD5 /* AddressMapper.h in Headers */,
-				00AB9652157F9EC700EDACD5 /* AddressMux.h in Headers */,
-				00AB9653157F9EC700EDACD5 /* AddressOffset.h in Headers */,
-				00AB9654157F9EC700EDACD5 /* Audio1Bit.h in Headers */,
-				00AB9655157F9EC700EDACD5 /* AudioCodec.h in Headers */,
-				00AB9656157F9EC700EDACD5 /* AudioPlayer.h in Headers */,
-				00AB9658157F9EC700EDACD5 /* ControlBus.h in Headers */,
-				00AB9659157F9EC700EDACD5 /* FloatingBus.h in Headers */,
-				00AB965A157F9EC700EDACD5 /* JoystickMapper.h in Headers */,
-				00AB965B157F9EC700EDACD5 /* Monitor.h in Headers */,
-				00AB965C157F9EC700EDACD5 /* RAM.h in Headers */,
-				00AB965D157F9EC700EDACD5 /* ROM.h in Headers */,
-				00AB965E157F9ECF00EDACD5 /* MOS6502.h in Headers */,
-				00AB965F157F9ECF00EDACD5 /* MOS6502IllegalOperations.h in Headers */,
-				00AB9660157F9ECF00EDACD5 /* MOS6502Opcodes.h in Headers */,
-				00AB9661157F9ECF00EDACD5 /* MOS6502Operations.h in Headers */,
-				00AB9662157F9ECF00EDACD5 /* MOS6530.h in Headers */,
-				00AB9663157F9ECF00EDACD5 /* MOSKIM1IO.h in Headers */,
-				00AB9664157F9ECF00EDACD5 /* MOSKIM1PLL.h in Headers */,
-				00AB9665157F9ED600EDACD5 /* MC6821.h in Headers */,
-				00AB9666157F9ED600EDACD5 /* MC6845.h in Headers */,
-				00AB966A157F9EE400EDACD5 /* W65C02S.h in Headers */,
-				00AB966B157F9EE400EDACD5 /* W65C02SOpcodes.h in Headers */,
-				00AB966C157F9EE400EDACD5 /* W65C02SOperations.h in Headers */,
-				00AB966D157F9EF000EDACD5 /* AppleIIInterface.h in Headers */,
-				00AB966E157F9EF400EDACD5 /* RS232Interface.h in Headers */,
-				00AB966F157F9EFE00EDACD5 /* AudioPlayerInterface.h in Headers */,
-				00AB9670157F9EFE00EDACD5 /* ControlBusInterface.h in Headers */,
-				00AB9671157F9EFE00EDACD5 /* CPUInterface.h in Headers */,
-				00AB9672157F9EFE00EDACD5 /* MemoryInterface.h in Headers */,
-				00AB9673157F9F0200EDACD5 /* DeviceInterface.h in Headers */,
-				00AB9674157F9F0200EDACD5 /* AudioInterface.h in Headers */,
-				00AB9675157F9F0200EDACD5 /* CanvasInterface.h in Headers */,
-				00AB9676157F9F0200EDACD5 /* StorageInterface.h in Headers */,
-				00AB9677157F9F0200EDACD5 /* JoystickInterface.h in Headers */,
-				00AB9678157F9F0200EDACD5 /* EthernetInterface.h in Headers */,
-				00AB9679157F9F0200EDACD5 /* MIDIInterface.h in Headers */,
-				00AB967A157F9F0200EDACD5 /* USBInterface.h in Headers */,
-				00AB967B157F9F0200EDACD5 /* VideoCaptureInterface.h in Headers */,
-				00AB967C157F9F0700EDACD5 /* IEEE488Interface.h in Headers */,
-				00AB967D157F9F0700EDACD5 /* IEEE1284Interface.h in Headers */,
-				00AB967E157F9F0700EDACD5 /* IEEE1394Interface.h in Headers */,
-				00AB9691157F9F2600EDACD5 /* OECommon.h in Headers */,
-				00AB9692157F9F2600EDACD5 /* OEComponent.h in Headers */,
-				00AB9693157F9F2600EDACD5 /* OEComponentFactory.h in Headers */,
-				00AB9694157F9F2600EDACD5 /* OEDevice.h in Headers */,
-				00AB9695157F9F2600EDACD5 /* OEDocument.h in Headers */,
-				00AB9696157F9F2600EDACD5 /* OEEmulation.h in Headers */,
-				00AB9697157F9F2600EDACD5 /* OEImage.h in Headers */,
-				00AB9698157F9F2600EDACD5 /* OEPackage.h in Headers */,
-				00AB9699157F9F2600EDACD5 /* OESound.h in Headers */,
-				00AB96A8158053C400EDACD5 /* AppleIIDisableC800.h in Headers */,
-				005316C51596D2BF007F3C86 /* Proxy.h in Headers */,
-				00839E481597060200BD4538 /* ATAController.h in Headers */,
-				00EA1F0615976F0200079A54 /* ATADevice.h in Headers */,
-				00EA1F0B159799C400079A54 /* RDCFFA.h in Headers */,
-				00F2797215B671EE00E58F4F /* MOS6522.h in Headers */,
-				0042499115B693DE0091ECAB /* AppleIIIMOS6502.h in Headers */,
-				0042499315B694A60091ECAB /* AppleIIIMOS6502Opcodes.h in Headers */,
-				0042499515B696EA0091ECAB /* AppleIIIMOS6502Operations.h in Headers */,
-				0042499715B8EA1C0091ECAB /* EmulationInterface.h in Headers */,
-				004E152D15B9042100FD22AB /* AppleIIISystemControl.h in Headers */,
+				49EB4E5218C6702200AD682A /* AppleDiskDrive525.h in Headers */,
+				49EB4E7E18C6702200AD682A /* AppleIISystemControl.h in Headers */,
+				49EB4EB518C6702200AD682A /* MOS6522.h in Headers */,
+				49EB4E5018C6702200AD682A /* Apple1Terminal.h in Headers */,
+				49EB4E4C18C6702200AD682A /* Apple1ACI.h in Headers */,
+				49EB4EE818C6702200AD682A /* StorageInterface.h in Headers */,
+				49EB4E4018C6702200AD682A /* OEDevice.h in Headers */,
+				49EB4EE718C6702200AD682A /* MIDIInterface.h in Headers */,
+				49EB4E4218C6702200AD682A /* OEDocument.h in Headers */,
+				49EB4EE118C6702200AD682A /* AudioInterface.h in Headers */,
+				49EB4E5E18C6702200AD682A /* AppleIIAudioOut.h in Headers */,
+				49EB4EAE18C6702200AD682A /* MOS6502Opcodes.h in Headers */,
+				49EB4E7018C6702200AD682A /* AppleIIIMOS6502.h in Headers */,
+				49EB4ED918C6702200AD682A /* RS232Interface.h in Headers */,
+				49EB4EE418C6702200AD682A /* EmulationInterface.h in Headers */,
+				49EB4EDF18C6702200AD682A /* PIAInterface.h in Headers */,
+				49EB4EDC18C6702200AD682A /* CPUInterface.h in Headers */,
+				49EB4E9018C6702200AD682A /* AddressOffset.h in Headers */,
+				49EB4E8A18C6702200AD682A /* AddressMapper.h in Headers */,
+				49EB4E6218C6702200AD682A /* AppleIIFloatingBus.h in Headers */,
+				49EB4E6618C6702200AD682A /* AppleIIIAddressDecoder.h in Headers */,
+				49EB4E7A18C6702200AD682A /* AppleIIKeyboard.h in Headers */,
+				49EB4E9E18C6702200AD682A /* FloatingBus.h in Headers */,
+				49EB4ED218C6702200AD682A /* W65C816S.h in Headers */,
+				49EB4ECF18C6702200AD682A /* W65C02SOpcodes.h in Headers */,
+				49EB4E9C18C6702200AD682A /* ControlBus.h in Headers */,
+				49EB4EA418C6702200AD682A /* Proxy.h in Headers */,
+				49EB4E6A18C6702200AD682A /* AppleIIIDiskIO.h in Headers */,
+				49EB4EB718C6702200AD682A /* MOS6530.h in Headers */,
+				49EB4EED18C6702200AD682A /* IEEE488Interface.h in Headers */,
+				49EB4E8218C6702200AD682A /* AppleLanguageCard.h in Headers */,
+				49EB4EA018C6702200AD682A /* JoystickMapper.h in Headers */,
+				49EB4EBF18C6702200AD682A /* MC6821.h in Headers */,
+				49EB4EDE18C6702200AD682A /* MemoryInterface.h in Headers */,
+				49EB4E9618C6702200AD682A /* Audio1Bit.h in Headers */,
+				49EB4E8418C6702200AD682A /* AppleSilentype.h in Headers */,
+				49EB4E5A18C6702200AD682A /* AppleIIAddressDecoder.h in Headers */,
+				49EB4EEC18C6702200AD682A /* IEEE1394Interface.h in Headers */,
+				49EB4E8018C6702200AD682A /* AppleIIVideo.h in Headers */,
+				49EB4EE318C6702200AD682A /* DeviceInterface.h in Headers */,
+				49EB4E6818C6702200AD682A /* AppleIIIBeeper.h in Headers */,
+				49EB4E7118C6702200AD682A /* AppleIIIMOS6502Opcodes.h in Headers */,
+				49EB4E4E18C6702200AD682A /* Apple1IO.h in Headers */,
+				49EB4EEB18C6702200AD682A /* IEEE1284Interface.h in Headers */,
+				49EB4E9A18C6702200AD682A /* AudioPlayer.h in Headers */,
+				49EB4E7618C6702200AD682A /* AppleIIISystemControl.h in Headers */,
+				49EB4E6418C6702200AD682A /* AppleIIGamePort.h in Headers */,
+				49EB4E5818C6702200AD682A /* AppleGraphicsTabletInterfaceCard.h in Headers */,
+				49EB4E7818C6702200AD682A /* AppleIIIVideo.h in Headers */,
+				49EB4EDB18C6702200AD682A /* ControlBusInterface.h in Headers */,
+				49EB4EC318C6702200AD682A /* MM58167.h in Headers */,
+				49EB4E5418C6702200AD682A /* AppleDiskIIInterfaceCard.h in Headers */,
+				49EB4E5C18C6702200AD682A /* AppleIIAudioIn.h in Headers */,
+				49EB4E4A18C6702200AD682A /* OESound.h in Headers */,
+				49EB4E7218C6702200AD682A /* AppleIIIMOS6502Operations.h in Headers */,
+				49EB4EDA18C6702200AD682A /* AudioPlayerInterface.h in Headers */,
+				49EB4E9818C6702200AD682A /* AudioCodec.h in Headers */,
+				49EB4E4818C6702200AD682A /* OEPackage.h in Headers */,
+				49EB4EE218C6702200AD682A /* CanvasInterface.h in Headers */,
+				49EB4E8818C6702200AD682A /* AddressDecoder.h in Headers */,
+				49EB4E5618C6702200AD682A /* AppleGraphicsTablet.h in Headers */,
+				49EB4EBD18C6702200AD682A /* MOSKIM1PLL.h in Headers */,
+				49EB4EC118C6702200AD682A /* MC6845.h in Headers */,
+				49EB4E6C18C6702200AD682A /* AppleIIIGamePort.h in Headers */,
+				49EB4E7C18C6702200AD682A /* AppleIISlotController.h in Headers */,
+				49EB4EC518C6702200AD682A /* RDCFFA.h in Headers */,
+				49EB4EE918C6702200AD682A /* USBInterface.h in Headers */,
+				49EB4EA218C6702200AD682A /* Monitor.h in Headers */,
+				49EB4EAC18C6702200AD682A /* MOS6502.h in Headers */,
+				49EB4E3E18C6702200AD682A /* OEComponentFactory.h in Headers */,
+				49EB4E7418C6702200AD682A /* AppleIIIRTC.h in Headers */,
+				49EB4EE518C6702200AD682A /* EthernetInterface.h in Headers */,
+				49EB4EE618C6702200AD682A /* JoystickInterface.h in Headers */,
+				49EB4ED818C6702200AD682A /* AppleIIInterface.h in Headers */,
+				49EB4E6E18C6702200AD682A /* AppleIIIKeyboard.h in Headers */,
+				49EB4E6018C6702200AD682A /* AppleIIDisableC800.h in Headers */,
+				49EB4E9418C6702200AD682A /* ATADevice.h in Headers */,
+				49EB4EA618C6702200AD682A /* RAM.h in Headers */,
+				49EB4EEA18C6702200AD682A /* VideoCaptureInterface.h in Headers */,
+				49EB4E8C18C6702200AD682A /* AddressMasker.h in Headers */,
+				49EB4EAD18C6702200AD682A /* MOS6502IllegalOperations.h in Headers */,
+				49EB4E4418C6702200AD682A /* OEEmulation.h in Headers */,
+				49EB4E3A18C6702200AD682A /* OECommon.h in Headers */,
+				49EB4E4618C6702200AD682A /* OEImage.h in Headers */,
+				49EB4ECC18C6702200AD682A /* VidexVideoterm.h in Headers */,
+				49EB4ECE18C6702200AD682A /* W65C02S.h in Headers */,
+				49EB4E3C18C6702200AD682A /* OEComponent.h in Headers */,
+				49EB4EBB18C6702200AD682A /* MOSKIM1IO.h in Headers */,
+				49EB4E8618C6702200AD682A /* AppleSilentypeInterfaceCard.h in Headers */,
+				49EB4ED718C6702200AD682A /* AppleIIIInterface.h in Headers */,
+				49EB4ED018C6702200AD682A /* W65C02SOperations.h in Headers */,
+				49EB4EA818C6702200AD682A /* ROM.h in Headers */,
+				49EB4EAF18C6702200AD682A /* MOS6502Operations.h in Headers */,
+				49EB4E8E18C6702200AD682A /* AddressMux.h in Headers */,
+				49EB4EAA18C6702200AD682A /* VRAM.h in Headers */,
+				49EB4EB918C6702200AD682A /* MOS6551.h in Headers */,
+				49EB4E9218C6702200AD682A /* ATAController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1517,7 +1564,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00CF208115B0D92600DA8E08 /* util.h in Headers */,
+				49EB4F0918C6737700AD682A /* util.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1624,7 +1671,7 @@
 		2A37F4A9FDCFA73011CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0440;
+				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = OpenEmulator;
 			};
 			buildConfigurationList = C05733CB08A9546B00998B17 /* Build configuration list for PBXProject "OpenEmulator" */;
@@ -1655,51 +1702,59 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				003E25E71070796700185260 /* images in Resources */,
-				00B974B410701DDA00BD1402 /* sounds in Resources */,
-				00D8448B0FFF04C0005802F0 /* DiskImage.icns in Resources */,
-				00D8448F0FFF04C0005802F0 /* Emulation.icns in Resources */,
-				00D844A90FFF04C0005802F0 /* OpenEmulator.icns in Resources */,
-				00D844B20FFF04C0005802F0 /* templates in Resources */,
-				00D844C90FFF0505005802F0 /* MainMenu.xib in Resources */,
-				00D844CC0FFF0505005802F0 /* Preferences.xib in Resources */,
-				00679D09100817F700B38748 /* TemplateChooser.xib in Resources */,
-				00C6C0C110602151004D084B /* roms in Resources */,
-				0078F655127348ED0042577E /* AudioControls.xib in Resources */,
-				00ED379C12779AD100BEF6BD /* AudioMax.png in Resources */,
-				00ED379D12779AD100BEF6BD /* AudioMin.png in Resources */,
-				00ED379E12779AD100BEF6BD /* AudioPlay.png in Resources */,
-				00ED37A012779AD100BEF6BD /* AudioStop.png in Resources */,
-				00ED37B912779DD900BEF6BD /* IconAudio.png in Resources */,
-				00ED37BA12779DD900BEF6BD /* IconColdRestart.png in Resources */,
-				00ED37BB12779DD900BEF6BD /* IconDebuggerBreak.png in Resources */,
-				00ED37BC12779DD900BEF6BD /* IconGeneral.png in Resources */,
-				00ED37BD12779DD900BEF6BD /* IconInspector.png in Resources */,
-				00ED37BE12779DD900BEF6BD /* IconPowerDown.png in Resources */,
-				00ED37BF12779DD900BEF6BD /* IconSleep.png in Resources */,
-				00ED37C012779DD900BEF6BD /* IconVideo.png in Resources */,
-				00ED37C112779DD900BEF6BD /* IconWakeUp.png in Resources */,
-				00ED37C212779DD900BEF6BD /* IconWarmRestart.png in Resources */,
-				00E442921278726B00713A05 /* IconDevices.png in Resources */,
-				00A72B951287A0F10083C6A7 /* Canvas.xib in Resources */,
-				00CAD7D912A04C22002B92E5 /* Emulation.xib in Resources */,
-				00F01B4712A0D6EC000527CA /* EmulationUnmount.png in Resources */,
-				0076FD6512A1ED8C00A3FEC7 /* AudioPause.png in Resources */,
-				00039CF812B01D540025D374 /* EmulationUnmountPressed.png in Resources */,
-				00039CFF12B01D540025D374 /* EmulationShowPressed.png in Resources */,
-				00039D2612B01EB40025D374 /* EmulationUnmountSelected.png in Resources */,
-				00039D2712B01EB40025D374 /* EmulationShowSelected.png in Resources */,
-				00039E0C12B0365A0025D374 /* EmulationUnmountRollover.png in Resources */,
-				00039E0D12B0365A0025D374 /* EmulationShowRollover.png in Resources */,
-				00D6729D12C9A256009F0D9E /* EmulationShow.png in Resources */,
-				00391D6112D3B570002C5ABD /* IconLibrary.png in Resources */,
-				00391D6412D3B588002C5ABD /* Library.xib in Resources */,
-				00391DAC12D3B94F002C5ABD /* library in Resources */,
-				00391F6C12D3FFF3002C5ABD /* TemplateChooserView.xib in Resources */,
-				0073DDBF136FCCC900087303 /* ToolbarBackground.png in Resources */,
-				001C9B02137FDD0500D1355B /* AudioRecord.png in Resources */,
-				007F08CF1459344600C3308D /* sparkle_dsa_pub.pem in Resources */,
-				007EF9C71570329D0073061E /* IconRevert.png in Resources */,
+				49EB4CF018C63BE500AD682A /* sparkle_dsa_pub.pem in Resources */,
+				49EB4CCB18C63BE500AD682A /* AudioPlay.png in Resources */,
+				49EB4CE018C63BE500AD682A /* IconRevert.png in Resources */,
+				49EB4D0C18C6536100AD682A /* Preferences.xib in Resources */,
+				49EB4CE218C63BE500AD682A /* IconVideo.png in Resources */,
+				49EB4D0718C6536100AD682A /* AudioControls.xib in Resources */,
+				49EB4CE318C63BE500AD682A /* IconWakeUp.png in Resources */,
+				49EB4CD718C63BE500AD682A /* EmulationUnmountSelected.png in Resources */,
+				49EB4CD118C63BE500AD682A /* EmulationShowPressed.png in Resources */,
+				49EB4D0D18C6536100AD682A /* TemplateChooser.xib in Resources */,
+				49EB4D0A18C6536100AD682A /* Library.xib in Resources */,
+				49EB4CC518C63BE500AD682A /* Preferences.xib in Resources */,
+				49EB4CD818C63BE500AD682A /* IconAudio.png in Resources */,
+				49EB4CCE18C63BE500AD682A /* DiskImage.icns in Resources */,
+				49EB4CDB18C63BE500AD682A /* IconDevices.png in Resources */,
+				49EB4CE118C63BE500AD682A /* IconSleep.png in Resources */,
+				496AF1DC18C677B600B35159 /* library in Resources */,
+				49EB4D0818C6536100AD682A /* Canvas.xib in Resources */,
+				49EB4CD018C63BE500AD682A /* EmulationShow.png in Resources */,
+				49EB4CD518C63BE500AD682A /* EmulationUnmountPressed.png in Resources */,
+				496AF1E018C746F300B35159 /* roms in Resources */,
+				496AF1DE18C677B600B35159 /* templates in Resources */,
+				49EB4CD618C63BE500AD682A /* EmulationUnmountRollover.png in Resources */,
+				49EB4CDD18C63BE500AD682A /* IconInspector.png in Resources */,
+				49EB4CDE18C63BE500AD682A /* IconLibrary.png in Resources */,
+				49EB4CE418C63BE500AD682A /* IconWarmRestart.png in Resources */,
+				49EB4CCF18C63BE500AD682A /* Emulation.icns in Resources */,
+				49EB4D0E18C6536100AD682A /* TemplateChooserView.xib in Resources */,
+				49EB4CD218C63BE500AD682A /* EmulationShowRollover.png in Resources */,
+				49EB4D0918C6536100AD682A /* Emulation.xib in Resources */,
+				49EB4CC418C63BE500AD682A /* MainMenu.xib in Resources */,
+				49EB4CDA18C63BE500AD682A /* IconDebuggerBreak.png in Resources */,
+				49EB4CC318C63BE500AD682A /* Library.xib in Resources */,
+				49EB4CC818C63BE500AD682A /* AudioMax.png in Resources */,
+				49EB4CC718C63BE500AD682A /* TemplateChooserView.xib in Resources */,
+				49EB4CE618C63BE500AD682A /* ToolbarBackground.png in Resources */,
+				496AF1DB18C677B600B35159 /* images in Resources */,
+				49EB4CC118C63BE500AD682A /* Canvas.xib in Resources */,
+				49EB4CC018C63BE500AD682A /* AudioControls.xib in Resources */,
+				49EB4CD918C63BE500AD682A /* IconColdRestart.png in Resources */,
+				496AF1DD18C677B600B35159 /* sounds in Resources */,
+				49EB4CD318C63BE500AD682A /* EmulationShowSelected.png in Resources */,
+				49EB4CDF18C63BE500AD682A /* IconPowerDown.png in Resources */,
+				49EB4CDC18C63BE500AD682A /* IconGeneral.png in Resources */,
+				49EB4CCC18C63BE500AD682A /* AudioRecord.png in Resources */,
+				49EB4CE518C63BE500AD682A /* OpenEmulator.icns in Resources */,
+				49EB4D0B18C6536100AD682A /* MainMenu.xib in Resources */,
+				49EB4CC918C63BE500AD682A /* AudioMin.png in Resources */,
+				49EB4CCA18C63BE500AD682A /* AudioPause.png in Resources */,
+				49EB4CC618C63BE500AD682A /* TemplateChooser.xib in Resources */,
+				49EB4CD418C63BE500AD682A /* EmulationUnmount.png in Resources */,
+				49EB4CCD18C63BE500AD682A /* AudioStop.png in Resources */,
+				49EB4CC218C63BE500AD682A /* Emulation.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1726,11 +1781,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0083630D1326C15300CB9A21 /* OpenGLCanvas.cpp in Sources */,
-				0083630F1326C15300CB9A21 /* OEVector.cpp in Sources */,
-				008363111326C15300CB9A21 /* PAAudio.cpp in Sources */,
-				00651A55155AE23500221A44 /* HIDJoystick.cpp in Sources */,
-				00651A56155AE23C00221A44 /* OEMatrix3.cpp in Sources */,
+				49EB4EFA18C6709F00AD682A /* OEMatrix3.cpp in Sources */,
+				49EB4EF818C6709F00AD682A /* HIDJoystick.cpp in Sources */,
+				49EB4F0018C6709F00AD682A /* PAAudio.cpp in Sources */,
+				49EB4EFE18C6709F00AD682A /* OpenGLCanvas.cpp in Sources */,
+				49EB4EFC18C6709F00AD682A /* OEVector.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1738,24 +1793,24 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00140DF0152D282400D4795D /* DIApple525DiskStorage.cpp in Sources */,
-				00140DF6152D36F900D4795D /* DIFileBackingStore.cpp in Sources */,
-				00140DFC152D371C00D4795D /* DI2IMGBackingStore.cpp in Sources */,
-				00140E04152D376400D4795D /* DIFDIDiskStorage.cpp in Sources */,
-				00140E0C152D37F500D4795D /* DIDC42BackingStore.cpp in Sources */,
-				00140E12152D395900D4795D /* DIV2DDiskStorage.cpp in Sources */,
-				0020AE731530A22700E3DF80 /* DICommon.cpp in Sources */,
-				00A06AE31533055600A494A7 /* DIATABlockStorage.cpp in Sources */,
-				00A06AE91533EE3100A494A7 /* DIApple35DiskStorage.cpp in Sources */,
-				0027E67E153738CC0066A9BE /* DIVDIBlockStorage.cpp in Sources */,
-				00536BC6153DD400005A5336 /* DIVMDKBlockStorage.cpp in Sources */,
-				007DEFAF153FB16800A9CC01 /* DIRAMBackingStore.cpp in Sources */,
-				007DEFB1153FB17500A9CC01 /* DIBackingStore.cpp in Sources */,
-				007DEFB3153FB5E800A9CC01 /* DIBlockStorage.cpp in Sources */,
-				007DEFBB1540608300A9CC01 /* DIRAWBlockStorage.cpp in Sources */,
-				0019177E1543D321009A301E /* DIDiskStorage.cpp in Sources */,
-				001917821543D347009A301E /* DILogicalDiskStorage.cpp in Sources */,
-				00B6A2DF15B1FC97005E7A5C /* DIDDLDiskStorage.cpp in Sources */,
+				49EB4D6118C66FDD00AD682A /* DIFileBackingStore.cpp in Sources */,
+				49EB4D6518C66FDD00AD682A /* DIRAMBackingStore.cpp in Sources */,
+				49EB4D6718C66FDD00AD682A /* DIRAWBlockStorage.cpp in Sources */,
+				49EB4D5518C66FDD00AD682A /* DIBlockStorage.cpp in Sources */,
+				49EB4D5B18C66FDD00AD682A /* DIDDLDiskStorage.cpp in Sources */,
+				49EB4D4D18C66FDD00AD682A /* DIApple35DiskStorage.cpp in Sources */,
+				49EB4D6318C66FDD00AD682A /* DILogicalDiskStorage.cpp in Sources */,
+				49EB4D5318C66FDD00AD682A /* DIBackingStore.cpp in Sources */,
+				49EB4D6C18C66FDD00AD682A /* DIVDIBlockStorage.cpp in Sources */,
+				49EB4D5718C66FDD00AD682A /* DICommon.cpp in Sources */,
+				49EB4D5118C66FDD00AD682A /* DIATABlockStorage.cpp in Sources */,
+				49EB4D5918C66FDD00AD682A /* DIDC42BackingStore.cpp in Sources */,
+				49EB4D5F18C66FDD00AD682A /* DIFDIDiskStorage.cpp in Sources */,
+				49EB4D4F18C66FDD00AD682A /* DIApple525DiskStorage.cpp in Sources */,
+				49EB4D6E18C66FDD00AD682A /* DIVMDKBlockStorage.cpp in Sources */,
+				49EB4D4B18C66FDD00AD682A /* DI2IMGBackingStore.cpp in Sources */,
+				49EB4D6A18C66FDD00AD682A /* DIV2DDiskStorage.cpp in Sources */,
+				49EB4D5D18C66FDD00AD682A /* DIDiskStorage.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1763,71 +1818,77 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00FC27D312D1070A0065E986 /* Apple1ACI.cpp in Sources */,
-				00FC27DB12D1070A0065E986 /* AppleIIAudioOut.cpp in Sources */,
-				00FC27DF12D1070A0065E986 /* AppleIIFloatingBus.cpp in Sources */,
-				00FC27E312D1070A0065E986 /* AppleIIKeyboard.cpp in Sources */,
-				00FC27E912D1070A0065E986 /* AppleIISlotController.cpp in Sources */,
-				00FC27EB12D1070A0065E986 /* AppleIIVideo.cpp in Sources */,
-				00FC27EE12D1070A0065E986 /* AppleDiskDrive525.cpp in Sources */,
-				00FC27EF12D1070A0065E986 /* AddressDecoder.cpp in Sources */,
-				00FC27F112D1070A0065E986 /* AddressOffset.cpp in Sources */,
-				00FC27F312D1070A0065E986 /* AudioCodec.cpp in Sources */,
-				00FC27F712D1070A0065E986 /* Monitor.cpp in Sources */,
-				00FC27F912D1070A0065E986 /* ControlBus.cpp in Sources */,
-				00FC27FB12D1070A0065E986 /* FloatingBus.cpp in Sources */,
-				00FC27FD12D1070A0065E986 /* RAM.cpp in Sources */,
-				00FC27FF12D1070A0065E986 /* ROM.cpp in Sources */,
-				00FC280312D1070A0065E986 /* MOS6502.cpp in Sources */,
-				00FC280812D1070A0065E986 /* MOS6530.cpp in Sources */,
-				00FC280A12D1070A0065E986 /* MOSKIM1IO.cpp in Sources */,
-				00FC280C12D1070A0065E986 /* MOSKIM1PLL.cpp in Sources */,
-				00FC280E12D1070A0065E986 /* MC6821.cpp in Sources */,
-				00FC281012D1070A0065E986 /* MC6845.cpp in Sources */,
-				00811E0012D251E9009AD2F0 /* AppleDiskIIInterfaceCard.cpp in Sources */,
-				00811F1312D2738B009AD2F0 /* AppleGraphicsTablet.cpp in Sources */,
-				00A973AB12E512F80084724F /* OEEmulation.cpp in Sources */,
-				00A973AD12E512F80084724F /* OEComponent.cpp in Sources */,
-				00A973AF12E512F80084724F /* OEComponentFactory.cpp in Sources */,
-				00A973B112E512F80084724F /* OEDocument.cpp in Sources */,
-				00A973B312E512F80084724F /* OEImage.cpp in Sources */,
-				00A973B512E512F80084724F /* OEPackage.cpp in Sources */,
-				00B019B513501507001E01BB /* OEDevice.cpp in Sources */,
-				00B5CB94136F0B6C007A7BED /* AppleSilentype.cpp in Sources */,
-				00247F38139D8F4C00B165D1 /* OECommon.cpp in Sources */,
-				002740B813A08A4F00E13D65 /* VidexVideoterm.cpp in Sources */,
-				00F397E4141655DA00C53A3E /* Apple1IO.cpp in Sources */,
-				004BD1C01425AA8500768B80 /* W65C02S.cpp in Sources */,
-				0029EEE214266B8900AD900E /* AddressMapper.cpp in Sources */,
-				00B7C646147B4B4100BB7E6B /* JoystickMapper.cpp in Sources */,
-				00B7C64A147B5B2B00BB7E6B /* AppleIIGamePort.cpp in Sources */,
-				0084D43614FC4FF80031A8A5 /* Audio1Bit.cpp in Sources */,
-				00A90FB5150D3A0E00BB2999 /* AudioInterface.cpp in Sources */,
-				00139F84151195E600B0E108 /* AppleIIAddressDecoder.cpp in Sources */,
-				00365CEB1516955C00978DF6 /* AddressMux.cpp in Sources */,
-				00936E8815170435006B0EAC /* AudioPlayer.cpp in Sources */,
-				00AD7028151AC41E00424637 /* OESound.cpp in Sources */,
-				001E096C1556339800405DC0 /* AppleLanguageCard.cpp in Sources */,
-				001E0970155633D000405DC0 /* AppleIIAudioIn.cpp in Sources */,
-				001E0971155633E700405DC0 /* Apple1Terminal.cpp in Sources */,
-				00651A57155AE3DF00221A44 /* MemoryInterface.cpp in Sources */,
-				00092E5C156AA9D4007A9E04 /* VRAM.cpp in Sources */,
-				00379132157B285F0020138F /* AppleGraphicsTabletInterfaceCard.cpp in Sources */,
-				00AB96A7158053C400EDACD5 /* AppleIIDisableC800.cpp in Sources */,
-				005316C31596D268007F3C86 /* AppleSilentypeInterfaceCard.cpp in Sources */,
-				005316C71596D2C8007F3C86 /* Proxy.cpp in Sources */,
-				00839E491597060700BD4538 /* ATAController.cpp in Sources */,
-				00EA1F0515976F0200079A54 /* ATADevice.cpp in Sources */,
-				00EA1F0A159799C400079A54 /* RDCFFA.cpp in Sources */,
-				00F2796F15B671E600E58F4F /* MOS6522.cpp in Sources */,
-				0042499015B693DE0091ECAB /* AppleIIIMOS6502.cpp in Sources */,
-				004E152A15B9041A00FD22AB /* AppleIIISystemControl.cpp in Sources */,
-				008696AD15C8FC94000737EE /* AppleIIIDiskIO.cpp in Sources */,
-				008696B015CB9048000737EE /* AppleIISystemControl.cpp in Sources */,
-				007F6C3715CD05370004D4C4 /* AppleIIIAddressDecoder.cpp in Sources */,
-				007F6C3A15CD06520004D4C4 /* MOS6551.cpp in Sources */,
-				007F6C3D15CD06930004D4C4 /* AppleIIIGamePort.cpp in Sources */,
-				00D96F4C15E010AD0066EB0C /* AppleIIIKeyboard.cpp in Sources */,
+				49EB4E3F18C6702200AD682A /* OEDevice.cpp in Sources */,
+				49EB4E6118C6702200AD682A /* AppleIIFloatingBus.cpp in Sources */,
+				49EB4EE018C6702200AD682A /* AudioInterface.cpp in Sources */,
+				49EB4E9B18C6702200AD682A /* ControlBus.cpp in Sources */,
+				49EB4E7318C6702200AD682A /* AppleIIIRTC.cpp in Sources */,
+				49EB4E3918C6702200AD682A /* OECommon.cpp in Sources */,
+				49EB4E8318C6702200AD682A /* AppleSilentype.cpp in Sources */,
+				49EB4E7D18C6702200AD682A /* AppleIISystemControl.cpp in Sources */,
+				49EB4E6D18C6702200AD682A /* AppleIIIKeyboard.cpp in Sources */,
+				49EB4E8718C6702200AD682A /* AddressDecoder.cpp in Sources */,
+				49EB4E4F18C6702200AD682A /* Apple1Terminal.cpp in Sources */,
+				49EB4E7718C6702200AD682A /* AppleIIIVideo.cpp in Sources */,
+				49EB4E4318C6702200AD682A /* OEEmulation.cpp in Sources */,
+				49EB4EDD18C6702200AD682A /* MemoryInterface.cpp in Sources */,
+				49EB4EA318C6702200AD682A /* Proxy.cpp in Sources */,
+				49EB4EB418C6702200AD682A /* MOS6522.cpp in Sources */,
+				49EB4E8B18C6702200AD682A /* AddressMasker.cpp in Sources */,
+				49EB4E5F18C6702200AD682A /* AppleIIDisableC800.cpp in Sources */,
+				49EB4EA518C6702200AD682A /* RAM.cpp in Sources */,
+				49EB4E4918C6702200AD682A /* OESound.cpp in Sources */,
+				49EB4E7B18C6702200AD682A /* AppleIISlotController.cpp in Sources */,
+				49EB4E8118C6702200AD682A /* AppleLanguageCard.cpp in Sources */,
+				49EB4E9318C6702200AD682A /* ATADevice.cpp in Sources */,
+				49EB4ECD18C6702200AD682A /* W65C02S.cpp in Sources */,
+				49EB4E5B18C6702200AD682A /* AppleIIAudioIn.cpp in Sources */,
+				49EB4E7918C6702200AD682A /* AppleIIKeyboard.cpp in Sources */,
+				49EB4E5118C6702200AD682A /* AppleDiskDrive525.cpp in Sources */,
+				49EB4E4518C6702200AD682A /* OEImage.cpp in Sources */,
+				49EB4ED118C6702200AD682A /* W65C816S.cpp in Sources */,
+				49EB4E5518C6702200AD682A /* AppleGraphicsTablet.cpp in Sources */,
+				49EB4E6F18C6702200AD682A /* AppleIIIMOS6502.cpp in Sources */,
+				49EB4E9918C6702200AD682A /* AudioPlayer.cpp in Sources */,
+				49EB4ECB18C6702200AD682A /* VidexVideoterm.cpp in Sources */,
+				49EB4EC418C6702200AD682A /* RDCFFA.cpp in Sources */,
+				49EB4E4118C6702200AD682A /* OEDocument.cpp in Sources */,
+				49EB4EC218C6702200AD682A /* MM58167.cpp in Sources */,
+				49EB4E3B18C6702200AD682A /* OEComponent.cpp in Sources */,
+				49EB4E4B18C6702200AD682A /* Apple1ACI.cpp in Sources */,
+				49EB4EA918C6702200AD682A /* VRAM.cpp in Sources */,
+				49EB4E9F18C6702200AD682A /* JoystickMapper.cpp in Sources */,
+				49EB4E4D18C6702200AD682A /* Apple1IO.cpp in Sources */,
+				49EB4E5918C6702200AD682A /* AppleIIAddressDecoder.cpp in Sources */,
+				49EB4E8518C6702200AD682A /* AppleSilentypeInterfaceCard.cpp in Sources */,
+				49EB4E6B18C6702200AD682A /* AppleIIIGamePort.cpp in Sources */,
+				49EB4E6318C6702200AD682A /* AppleIIGamePort.cpp in Sources */,
+				49EB4EBE18C6702200AD682A /* MC6821.cpp in Sources */,
+				49EB4E5D18C6702200AD682A /* AppleIIAudioOut.cpp in Sources */,
+				49EB4EBC18C6702200AD682A /* MOSKIM1PLL.cpp in Sources */,
+				49EB4EBA18C6702200AD682A /* MOSKIM1IO.cpp in Sources */,
+				49EB4E9D18C6702200AD682A /* FloatingBus.cpp in Sources */,
+				49EB4E9518C6702200AD682A /* Audio1Bit.cpp in Sources */,
+				49EB4E6718C6702200AD682A /* AppleIIIBeeper.cpp in Sources */,
+				49EB4E8918C6702200AD682A /* AddressMapper.cpp in Sources */,
+				49EB4E4718C6702200AD682A /* OEPackage.cpp in Sources */,
+				49EB4E3D18C6702200AD682A /* OEComponentFactory.cpp in Sources */,
+				49EB4EAB18C6702200AD682A /* MOS6502.cpp in Sources */,
+				49EB4EC018C6702200AD682A /* MC6845.cpp in Sources */,
+				49EB4E6518C6702200AD682A /* AppleIIIAddressDecoder.cpp in Sources */,
+				49EB4E8D18C6702200AD682A /* AddressMux.cpp in Sources */,
+				49EB4E7518C6702200AD682A /* AppleIIISystemControl.cpp in Sources */,
+				49EB4E7F18C6702200AD682A /* AppleIIVideo.cpp in Sources */,
+				49EB4E6918C6702200AD682A /* AppleIIIDiskIO.cpp in Sources */,
+				49EB4EB618C6702200AD682A /* MOS6530.cpp in Sources */,
+				49EB4EB818C6702200AD682A /* MOS6551.cpp in Sources */,
+				49EB4E5318C6702200AD682A /* AppleDiskIIInterfaceCard.cpp in Sources */,
+				49EB4E5718C6702200AD682A /* AppleGraphicsTabletInterfaceCard.cpp in Sources */,
+				49EB4E9118C6702200AD682A /* ATAController.cpp in Sources */,
+				49EB4E8F18C6702200AD682A /* AddressOffset.cpp in Sources */,
+				49EB4E9718C6702200AD682A /* AudioCodec.cpp in Sources */,
+				49EB4EA718C6702200AD682A /* ROM.cpp in Sources */,
+				49EB4EA118C6702200AD682A /* Monitor.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1835,7 +1896,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00CF208015B0D92200DA8E08 /* util.cpp in Sources */,
+				49EB4F0818C6737700AD682A /* util.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1843,36 +1904,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				00D845830FFF0FD2005802F0 /* main.m in Sources */,
-				00D845860FFF0FD2005802F0 /* PreferencesWindowController.m in Sources */,
-				00A0B8041069761A007930A5 /* Document.mm in Sources */,
-				0071E3BA10803F7300F2D54F /* TemplateChooserItem.mm in Sources */,
-				00B5709E10863C2A00CDE4A7 /* TemplateChooserWindowController.m in Sources */,
-				008107DE1120C57600D744FB /* TemplateChooserViewController.m in Sources */,
-				00954E781277B79E00C17203 /* EmulationOutlineCell.m in Sources */,
-				00954E991277BB8E00C17203 /* EmulationWindowController.m in Sources */,
-				00954EA71277BC1200C17203 /* AudioControlsWindowController.mm in Sources */,
-				00A72B6F12879F650083C6A7 /* CanvasView.mm in Sources */,
-				00A72B7012879F690083C6A7 /* CanvasWindowController.m in Sources */,
-				00BB34B412C5C5AE007332B5 /* EmulationItem.mm in Sources */,
-				00F21CE712C7C7EE00A809EF /* VerticallyCenteredTextFieldCell.m in Sources */,
-				00391CB312D3A320002C5ABD /* LibraryWindowController.m in Sources */,
-				0039211812D43448002C5ABD /* BackgroundView.m in Sources */,
-				00F35D7312EF049B0027B9E4 /* EmulationOutlineView.m in Sources */,
-				0073DD9F136FCC1100087303 /* CanvasToolbarView.m in Sources */,
-				006B5CD013826D0700EEB5BC /* CanvasWindow.m in Sources */,
-				00BDB1F713863188004DF2AF /* CanvasPrintView.m in Sources */,
-				008F2FE7138E0AD600409723 /* DocumentController.mm in Sources */,
-				009085401395D23D00B7D75F /* LibraryItem.mm in Sources */,
-				00D75C691399FFDB004AA153 /* LibraryTableCell.m in Sources */,
-				004763D2139C94F30016277E /* LibraryTableView.m in Sources */,
-				0009068E141D2A0300F06D99 /* NSStringAdditions.mm in Sources */,
-				0014DF14148286A5006A7660 /* Application.m in Sources */,
-				00D7E410158D1E4B00EBF8FA /* AddressMasker.cpp in Sources */,
-				0044FDD515D3784500F82C28 /* MM58167.cpp in Sources */,
-				0077272015D81387008AB5A2 /* AppleIIIBeeper.cpp in Sources */,
-				008CB9A715E7B08A00027B7B /* AppleIIIRTC.cpp in Sources */,
-				007A0B0C15EDD16100DFD300 /* AppleIIIVideo.cpp in Sources */,
+				49EB4CB718C63BE500AD682A /* CanvasView.mm in Sources */,
+				49EB4CEA18C63BE500AD682A /* LibraryTableView.m in Sources */,
+				49EB4CBF18C63BE500AD682A /* EmulationWindowController.m in Sources */,
+				49EB4CB418C63BE500AD682A /* BackgroundView.m in Sources */,
+				49EB4CBC18C63BE500AD682A /* EmulationItem.mm in Sources */,
+				49EB4CF218C63BE500AD682A /* TemplateChooserViewController.m in Sources */,
+				49EB4CB818C63BE500AD682A /* CanvasWindow.m in Sources */,
+				49EB4CEB18C63BE500AD682A /* LibraryWindowController.m in Sources */,
+				49EB4CBE18C63BE500AD682A /* EmulationOutlineView.m in Sources */,
+				49EB4CE818C63BE500AD682A /* LibraryItem.mm in Sources */,
+				49EB4CED18C63BE500AD682A /* NSStringAdditions.mm in Sources */,
+				49EB4CEE18C63BE500AD682A /* PreferencesWindowController.m in Sources */,
+				49EB4CBD18C63BE500AD682A /* EmulationOutlineCell.m in Sources */,
+				49EB4CEC18C63BE500AD682A /* main.m in Sources */,
+				49EB4CB918C63BE500AD682A /* CanvasWindowController.m in Sources */,
+				49EB4CB518C63BE500AD682A /* CanvasPrintView.m in Sources */,
+				49EB4CBA18C63BE500AD682A /* Document.mm in Sources */,
+				49EB4CBB18C63BE500AD682A /* DocumentController.mm in Sources */,
+				49EB4CE918C63BE500AD682A /* LibraryTableCell.m in Sources */,
+				49EB4CF418C63BE500AD682A /* VerticallyCenteredTextFieldCell.m in Sources */,
+				49EB4CF318C63BE500AD682A /* TemplateChooserWindowController.m in Sources */,
+				49EB4CB318C63BE500AD682A /* AudioControlsWindowController.mm in Sources */,
+				49EB4CF118C63BE500AD682A /* TemplateChooserItem.mm in Sources */,
+				49EB4CB218C63BE500AD682A /* Application.m in Sources */,
+				49EB4CB618C63BE500AD682A /* CanvasToolbarView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1907,68 +1963,132 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		00391D6212D3B588002C5ABD /* Library.xib */ = {
+		49EB4C6618C63BE500AD682A /* AudioControls.xib */ = {
 			isa = PBXVariantGroup;
 			children = (
-				00391D6312D3B588002C5ABD /* English */,
-			);
-			name = Library.xib;
-			sourceTree = "<group>";
-		};
-		00391F6A12D3FFF3002C5ABD /* TemplateChooserView.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				00391F6B12D3FFF3002C5ABD /* English */,
-			);
-			name = TemplateChooserView.xib;
-			sourceTree = "<group>";
-		};
-		00679D06100817F700B38748 /* TemplateChooser.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				00679D07100817F700B38748 /* English */,
-			);
-			name = TemplateChooser.xib;
-			sourceTree = "<group>";
-		};
-		0078F653127348ED0042577E /* AudioControls.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				0078F654127348ED0042577E /* English */,
+				49EB4C6718C63BE500AD682A /* English */,
 			);
 			name = AudioControls.xib;
 			sourceTree = "<group>";
 		};
-		00A72B931287A0F10083C6A7 /* Canvas.xib */ = {
+		49EB4C6818C63BE500AD682A /* Canvas.xib */ = {
 			isa = PBXVariantGroup;
 			children = (
-				00A72B941287A0F10083C6A7 /* English */,
+				49EB4C6918C63BE500AD682A /* English */,
 			);
 			name = Canvas.xib;
 			sourceTree = "<group>";
 		};
-		00CAD7D712A04C22002B92E5 /* Emulation.xib */ = {
+		49EB4C6A18C63BE500AD682A /* Emulation.xib */ = {
 			isa = PBXVariantGroup;
 			children = (
-				00CAD7D812A04C22002B92E5 /* English */,
+				49EB4C6B18C63BE500AD682A /* English */,
 			);
 			name = Emulation.xib;
 			sourceTree = "<group>";
 		};
-		00D844BD0FFF0505005802F0 /* MainMenu.xib */ = {
+		49EB4C6C18C63BE500AD682A /* Library.xib */ = {
 			isa = PBXVariantGroup;
 			children = (
-				00D844BE0FFF0505005802F0 /* English */,
+				49EB4C6D18C63BE500AD682A /* English */,
+			);
+			name = Library.xib;
+			sourceTree = "<group>";
+		};
+		49EB4C6E18C63BE500AD682A /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4C6F18C63BE500AD682A /* English */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";
 		};
-		00D844C30FFF0505005802F0 /* Preferences.xib */ = {
+		49EB4C7018C63BE500AD682A /* Preferences.xib */ = {
 			isa = PBXVariantGroup;
 			children = (
-				00D844C40FFF0505005802F0 /* English */,
+				49EB4C7118C63BE500AD682A /* English */,
 			);
 			name = Preferences.xib;
+			sourceTree = "<group>";
+		};
+		49EB4C7218C63BE500AD682A /* TemplateChooser.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4C7318C63BE500AD682A /* English */,
+			);
+			name = TemplateChooser.xib;
+			sourceTree = "<group>";
+		};
+		49EB4C7418C63BE500AD682A /* TemplateChooserView.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4C7518C63BE500AD682A /* English */,
+			);
+			name = TemplateChooserView.xib;
+			sourceTree = "<group>";
+		};
+		49EB4CF718C6536000AD682A /* AudioControls.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4CF818C6536000AD682A /* English */,
+			);
+			name = AudioControls.xib;
+			sourceTree = "<group>";
+		};
+		49EB4CF918C6536000AD682A /* Canvas.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4CFA18C6536000AD682A /* English */,
+			);
+			name = Canvas.xib;
+			sourceTree = "<group>";
+		};
+		49EB4CFB18C6536000AD682A /* Emulation.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4CFC18C6536000AD682A /* English */,
+			);
+			name = Emulation.xib;
+			sourceTree = "<group>";
+		};
+		49EB4CFD18C6536000AD682A /* Library.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4CFE18C6536000AD682A /* English */,
+			);
+			name = Library.xib;
+			sourceTree = "<group>";
+		};
+		49EB4CFF18C6536000AD682A /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4D0018C6536000AD682A /* English */,
+			);
+			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+		49EB4D0118C6536000AD682A /* Preferences.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4D0218C6536100AD682A /* English */,
+			);
+			name = Preferences.xib;
+			sourceTree = "<group>";
+		};
+		49EB4D0318C6536100AD682A /* TemplateChooser.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4D0418C6536100AD682A /* English */,
+			);
+			name = TemplateChooser.xib;
+			sourceTree = "<group>";
+		};
+		49EB4D0518C6536100AD682A /* TemplateChooserView.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49EB4D0618C6536100AD682A /* English */,
+			);
+			name = TemplateChooserView.xib;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -1978,6 +2098,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "emulation-hal";
 			};
 			name = Debug;
@@ -1986,6 +2109,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "emulation-hal";
 			};
 			name = Release;
@@ -1994,6 +2120,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -2002,6 +2131,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -2010,6 +2142,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = emulation;
 			};
 			name = Debug;
@@ -2018,6 +2153,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = emulation;
 			};
 			name = Release;
@@ -2026,6 +2164,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -2034,6 +2175,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -2043,14 +2187,12 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-					macosx,
-					"\"$(SRCROOT)/macosx\"",
-				);
-				INFOPLIST_FILE = macosx/Info.plist;
-				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					/opt/local/lib,
+					/Users/raw/devel/OpenEmulator/src/macosx,
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "$(SRCROOT)/src/macosx/Info.plist";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = OpenEmulator;
 			};
 			name = Debug;
@@ -2060,14 +2202,12 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-					macosx,
-					"\"$(SRCROOT)/macosx\"",
-				);
-				INFOPLIST_FILE = macosx/Info.plist;
-				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					/opt/local/lib,
+					/Users/raw/devel/OpenEmulator/src/macosx,
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "$(SRCROOT)/src/macosx/Info.plist";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = OpenEmulator;
 			};
 			name = Release;
@@ -2075,24 +2215,39 @@
 		C05733CC08A9546B00998B17 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/lib/**",
+					/opt/local/Library/Frameworks,
+					/opt/local/lib,
+					/usr/local/lib,
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					/usr/include/libxml2,
-					/usr/local/include,
 					/opt/local/include,
+					/usr/local/include,
+					/usr/include/libxml2,
 				);
 				LIBRARY_SEARCH_PATHS = (
-					/usr/local/lib,
+					"$(SRCROOT)/lib/**",
 					/opt/local/lib,
+					/usr/local/lib,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
@@ -2100,23 +2255,38 @@
 		C05733CD08A9546B00998B17 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/lib/**",
+					/opt/local/Library/Frameworks,
+					/opt/local/lib,
+					/usr/local/lib,
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					/usr/include/libxml2,
-					/usr/local/include,
 					/opt/local/include,
+					/usr/local/include,
+					/usr/include/libxml2,
 				);
 				LIBRARY_SEARCH_PATHS = (
-					/usr/local/lib,
+					"$(SRCROOT)/lib/**",
 					/opt/local/lib,
+					/usr/local/lib,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = NO;
 			};
 			name = Release;


### PR DESCRIPTION
This change makes it possible (for me, at least) to build & run OpenEmulator OSX Mavericks. It should be possible to build under (and for) earlier versions of OSX by making minor adjustments.

Running the emulator obviously requires roms.
