### PR TITLE
AppleIIEVideo.cpp: fix AN2/AN3 case fallthrough

### DIFF
--- a/src/libemulation/Implementation/Apple/AppleIIEVideo.cpp
+++ b/src/libemulation/Implementation/Apple/AppleIIEVideo.cpp
@@ -571,8 +571,13 @@ void AppleIIEVideo::notify(OEComponent *sender, int notification, void *data)
         {
             case APPLEII_AN2_DID_CHANGE:
                 an2 = *((bool *)data);
+
+                break;
+
             case APPLEII_AN3_DID_CHANGE:
                 an3 = *((bool *)data);
+
+                break;
         }
         refreshVideo();
         configureDraw();


### PR DESCRIPTION
Thanks to user @stivo on the Apple2Infinitum Slack for noticing this.