### PR TITLE
Fix Apple-1 character mapping

### DIFF
--- a/src/libemulation/Implementation/Apple/Apple1Terminal.cpp
+++ b/src/libemulation/Implementation/Apple/Apple1Terminal.cpp
@@ -318,11 +318,16 @@ void Apple1Terminal::loadFont(OEData *data)
     
     for (OEInt c = 0; c < FONT_SIZE; c++)
     {
+        // Apple-1 character mapping:
+        // invert bit 6 (0x40), remove bit 5 (0x20), concat with bits 4:0
+        // result is 6-bit index = {~bit6, bit4, bit3, bit2, bit1, bit0}
+        OEInt apple1c = ((~c & 0x40) >> 1) | (c & 0x1F);
+
         for (OEInt y = 0; y < FONT_HEIGHT; y++)
         {
             for (OEInt x = 0; x < FONT_WIDTH; x++)
             {
-                bool b = (data->at((c & cMask) * FONT_HEIGHT + y) << (x >> 1)) & 0x40;
+                bool b = (data->at((apple1c & cMask) * FONT_HEIGHT + y) << (x >> 1)) & 0x40;
                 
                 font[(c * FONT_HEIGHT + y) * FONT_WIDTH + x] = b ? 0xff : 0x00;
             }


### PR DESCRIPTION
Fix Apple-1 character mapping issue as described here:  https://github.com/openemulator/libemulation/issues/47

Here is the Apple-1 test program from the original user's manual:
```
0: A9 0 AA 20 EF FF E8 8A 4C 2 0
0R
```

Below is a screenshot of the test program running on my replica Apple-1.

![apple1-test-program](https://github.com/user-attachments/assets/f9b80971-75df-4800-abba-9cb9a3cac1eb)

For comparison, here is a screenshot showing the test program running on the current version of OpenEmulator. Note that the last 32 characters are incorrect.

<img width="641" height="533" alt="Screenshot 2025-07-23 at 7 29 45 PM" src="https://github.com/user-attachments/assets/5b1fe16a-df31-44fb-8f35-763f81f74157" />

Here is the OpenEmulator output after this fix. Note that the program output now matches the result from the replica Apple-1.

<img width="641" height="534" alt="Screenshot 2025-07-23 at 7 31 23 PM" src="https://github.com/user-attachments/assets/9c78c554-cb2c-42b2-ab06-5219b50275c6" />

